### PR TITLE
feat: Add conversation reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,15 @@ Have a conversation with context maintained across messages.
 }
 ```
 
+### 🧹 clear_conversations
+Clear all conversation history and start fresh. Useful when switching topics or when context becomes too large.
+
+```typescript
+{
+  // No parameters required
+}
+```
+
 ### 📋 list_ducks
 List all configured providers and their health status.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { duckArt, getRandomDuckMessage } from './utils/ascii-art.js';
 // Import tools
 import { askDuckTool } from './tools/ask-duck.js';
 import { chatDuckTool } from './tools/chat-duck.js';
+import { clearConversationsTool } from './tools/clear-conversations.js';
 import { listDucksTool } from './tools/list-ducks.js';
 import { listModelsTool } from './tools/list-models.js';
 import { compareDucksTool } from './tools/compare-ducks.js';
@@ -141,6 +142,12 @@ export class RubberDuckServer {
           case 'chat_with_duck':
             return await chatDuckTool(
               this.providerManager,
+              this.conversationManager,
+              args
+            );
+
+          case 'clear_conversations':
+            return clearConversationsTool(
               this.conversationManager,
               args
             );
@@ -413,6 +420,14 @@ export class RubberDuckServer {
             },
           },
           required: ['conversation_id', 'message'],
+        },
+      },
+      {
+        name: 'clear_conversations',
+        description: 'Clear all conversation history and start fresh',
+        inputSchema: {
+          type: 'object',
+          properties: {},
         },
       },
       {

--- a/src/services/conversation.ts
+++ b/src/services/conversation.ts
@@ -124,4 +124,23 @@ export class ConversationManager {
 
     return messages;
   }
+
+  clearAll(): { conversationsCleared: number; messagesCleared: number } {
+    let totalMessages = 0;
+    
+    // Count total messages across all conversations
+    for (const conversation of this.conversations.values()) {
+      totalMessages += conversation.messages.length;
+    }
+    
+    const conversationsCleared = this.conversations.size;
+    this.conversations.clear();
+    
+    logger.info(`Cleared ${conversationsCleared} conversations with ${totalMessages} total messages`);
+    
+    return {
+      conversationsCleared,
+      messagesCleared: totalMessages,
+    };
+  }
 }

--- a/src/tools/clear-conversations.ts
+++ b/src/tools/clear-conversations.ts
@@ -1,0 +1,24 @@
+import { ConversationManager } from '../services/conversation.js';
+import { logger } from '../utils/logger.js';
+
+export function clearConversationsTool(
+  conversationManager: ConversationManager,
+  _args: any
+) {
+  const result = conversationManager.clearAll();
+  
+  logger.info(`User cleared ${result.conversationsCleared} conversations`);
+  
+  const message = result.conversationsCleared === 0 
+    ? '🧹 No conversations to clear - memory is already empty!'
+    : `🧹 Cleared ${result.conversationsCleared} conversation${result.conversationsCleared === 1 ? '' : 's'} (${result.messagesCleared} message${result.messagesCleared === 1 ? '' : 's'})`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `${message}\n\n🦆 All ducks now have a fresh start! Previous conversation context has been removed.`,
+      },
+    ],
+  };
+}

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { ConversationManager } from '../src/services/conversation.js';
+
+// Mock logger to avoid console noise during tests
+jest.mock('../src/utils/logger');
+
+describe('ConversationManager', () => {
+  let conversationManager: ConversationManager;
+
+  beforeEach(() => {
+    conversationManager = new ConversationManager();
+  });
+
+  describe('conversation creation and retrieval', () => {
+    it('should create a new conversation', () => {
+      const conversation = conversationManager.createConversation('test-1', 'openai');
+      
+      expect(conversation.id).toBe('test-1');
+      expect(conversation.provider).toBe('openai');
+      expect(conversation.messages).toHaveLength(0);
+      expect(conversation.createdAt).toBeInstanceOf(Date);
+      expect(conversation.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should retrieve an existing conversation', () => {
+      conversationManager.createConversation('test-1', 'openai');
+      const retrieved = conversationManager.getConversation('test-1');
+      
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.id).toBe('test-1');
+    });
+
+    it('should return undefined for non-existent conversation', () => {
+      const retrieved = conversationManager.getConversation('nonexistent');
+      expect(retrieved).toBeUndefined();
+    });
+  });
+
+  describe('message handling', () => {
+    beforeEach(() => {
+      conversationManager.createConversation('test-1', 'openai');
+    });
+
+    it('should add messages to conversation', () => {
+      const message = {
+        role: 'user' as const,
+        content: 'Hello duck',
+        timestamp: new Date(),
+      };
+
+      const conversation = conversationManager.addMessage('test-1', message);
+      
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0]).toEqual(message);
+      expect(conversation.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should throw error for non-existent conversation when adding message', () => {
+      const message = {
+        role: 'user' as const,
+        content: 'Hello duck',
+        timestamp: new Date(),
+      };
+
+      expect(() => {
+        conversationManager.addMessage('nonexistent', message);
+      }).toThrow('Conversation nonexistent not found');
+    });
+
+    it('should trim conversations that exceed max size', () => {
+      // Add 55 messages (exceeds max of 50)
+      for (let i = 0; i < 55; i++) {
+        conversationManager.addMessage('test-1', {
+          role: 'user' as const,
+          content: `Message ${i}`,
+          timestamp: new Date(),
+        });
+      }
+
+      const conversation = conversationManager.getConversation('test-1');
+      
+      // Should be trimmed to 50 messages
+      expect(conversation!.messages).toHaveLength(50);
+      // Should keep the latest messages
+      expect(conversation!.messages[0].content).toBe('Message 5');
+      expect(conversation!.messages[49].content).toBe('Message 54');
+    });
+  });
+
+  describe('provider switching', () => {
+    beforeEach(() => {
+      conversationManager.createConversation('test-1', 'openai');
+    });
+
+    it('should switch provider and add system message', () => {
+      const conversation = conversationManager.switchProvider('test-1', 'groq');
+      
+      expect(conversation.provider).toBe('groq');
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0].role).toBe('system');
+      expect(conversation.messages[0].content).toBe('Switched to groq duck');
+      expect(conversation.messages[0].provider).toBe('groq');
+    });
+
+    it('should throw error for non-existent conversation when switching provider', () => {
+      expect(() => {
+        conversationManager.switchProvider('nonexistent', 'groq');
+      }).toThrow('Conversation nonexistent not found');
+    });
+  });
+
+  describe('conversation context', () => {
+    beforeEach(() => {
+      conversationManager.createConversation('test-1', 'openai');
+      
+      // Add some messages
+      for (let i = 0; i < 5; i++) {
+        conversationManager.addMessage('test-1', {
+          role: 'user' as const,
+          content: `Message ${i}`,
+          timestamp: new Date(),
+        });
+      }
+    });
+
+    it('should return all messages when no limit specified', () => {
+      const context = conversationManager.getConversationContext('test-1');
+      expect(context).toHaveLength(5);
+    });
+
+    it('should return limited messages when maxMessages specified', () => {
+      const context = conversationManager.getConversationContext('test-1', 3);
+      expect(context).toHaveLength(3);
+      // Should return the last 3 messages
+      expect(context[0].content).toBe('Message 2');
+      expect(context[2].content).toBe('Message 4');
+    });
+
+    it('should return empty array for non-existent conversation', () => {
+      const context = conversationManager.getConversationContext('nonexistent');
+      expect(context).toEqual([]);
+    });
+  });
+
+  describe('conversation management', () => {
+    it('should list all conversations', () => {
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.createConversation('test-2', 'groq');
+      
+      const list = conversationManager.listConversations();
+      expect(list).toHaveLength(2);
+      expect(list[0].id).toBe('test-1');
+      expect(list[1].id).toBe('test-2');
+      expect(list[0].messageCount).toBe(0);
+    });
+
+    it('should delete conversation', () => {
+      conversationManager.createConversation('test-1', 'openai');
+      
+      const deleted = conversationManager.deleteConversation('test-1');
+      expect(deleted).toBe(true);
+      
+      const retrieved = conversationManager.getConversation('test-1');
+      expect(retrieved).toBeUndefined();
+    });
+
+    it('should return false when deleting non-existent conversation', () => {
+      const deleted = conversationManager.deleteConversation('nonexistent');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('clearAll functionality', () => {
+    it('should clear empty conversation list', () => {
+      const result = conversationManager.clearAll();
+      
+      expect(result.conversationsCleared).toBe(0);
+      expect(result.messagesCleared).toBe(0);
+    });
+
+    it('should clear single conversation', () => {
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'Hello',
+        timestamp: new Date(),
+      });
+
+      const result = conversationManager.clearAll();
+      
+      expect(result.conversationsCleared).toBe(1);
+      expect(result.messagesCleared).toBe(1);
+      
+      // Verify conversations are actually cleared
+      const retrieved = conversationManager.getConversation('test-1');
+      expect(retrieved).toBeUndefined();
+    });
+
+    it('should clear multiple conversations with correct counts', () => {
+      // Create first conversation with 2 messages
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'Hello 1',
+        timestamp: new Date(),
+      });
+      conversationManager.addMessage('test-1', {
+        role: 'assistant' as const,
+        content: 'Hi 1',
+        timestamp: new Date(),
+      });
+
+      // Create second conversation with 3 messages
+      conversationManager.createConversation('test-2', 'groq');
+      conversationManager.addMessage('test-2', {
+        role: 'user' as const,
+        content: 'Hello 2',
+        timestamp: new Date(),
+      });
+      conversationManager.addMessage('test-2', {
+        role: 'assistant' as const,
+        content: 'Hi 2',
+        timestamp: new Date(),
+      });
+      conversationManager.addMessage('test-2', {
+        role: 'user' as const,
+        content: 'Follow up',
+        timestamp: new Date(),
+      });
+
+      const result = conversationManager.clearAll();
+      
+      expect(result.conversationsCleared).toBe(2);
+      expect(result.messagesCleared).toBe(5);
+      
+      // Verify all conversations are cleared
+      expect(conversationManager.getConversation('test-1')).toBeUndefined();
+      expect(conversationManager.getConversation('test-2')).toBeUndefined();
+      expect(conversationManager.listConversations()).toHaveLength(0);
+    });
+
+    it('should allow new conversations after clear', () => {
+      // Create and clear
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.clearAll();
+      
+      // Create new conversation after clear
+      const newConversation = conversationManager.createConversation('test-2', 'groq');
+      
+      expect(newConversation.id).toBe('test-2');
+      expect(newConversation.provider).toBe('groq');
+      expect(conversationManager.listConversations()).toHaveLength(1);
+    });
+  });
+
+  describe('conversation persistence', () => {
+    it('should maintain conversation between message additions', () => {
+      conversationManager.createConversation('test-1', 'openai');
+      
+      // Add first message
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'First message',
+        timestamp: new Date(),
+      });
+      
+      // Add second message
+      conversationManager.addMessage('test-1', {
+        role: 'assistant' as const,
+        content: 'First response',
+        timestamp: new Date(),
+      });
+      
+      const conversation = conversationManager.getConversation('test-1');
+      expect(conversation!.messages).toHaveLength(2);
+      expect(conversation!.messages[0].content).toBe('First message');
+      expect(conversation!.messages[1].content).toBe('First response');
+    });
+
+    it('should handle provider switching without losing messages', () => {
+      conversationManager.createConversation('test-1', 'openai');
+      
+      // Add initial message
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'Before switch',
+        timestamp: new Date(),
+      });
+      
+      // Switch provider
+      conversationManager.switchProvider('test-1', 'groq');
+      
+      // Add message after switch
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'After switch',
+        timestamp: new Date(),
+      });
+      
+      const conversation = conversationManager.getConversation('test-1');
+      expect(conversation!.messages).toHaveLength(3);
+      expect(conversation!.messages[0].content).toBe('Before switch');
+      expect(conversation!.messages[1].content).toBe('Switched to groq duck');
+      expect(conversation!.messages[2].content).toBe('After switch');
+      expect(conversation!.provider).toBe('groq');
+    });
+  });
+});

--- a/tests/tools/clear-conversations.test.ts
+++ b/tests/tools/clear-conversations.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { clearConversationsTool } from '../../src/tools/clear-conversations.js';
+import { ConversationManager } from '../../src/services/conversation.js';
+
+// Mock logger to avoid console noise during tests
+jest.mock('../../src/utils/logger');
+
+describe('clear_conversations tool', () => {
+  let conversationManager: ConversationManager;
+
+  beforeEach(() => {
+    conversationManager = new ConversationManager();
+  });
+
+  describe('tool execution', () => {
+    it('should call ConversationManager.clearAll and return proper response format', () => {
+      // Create some conversations first
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'Hello',
+        timestamp: new Date(),
+      });
+
+      const result = clearConversationsTool(conversationManager, {});
+      
+      expect(result).toHaveProperty('content');
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toHaveProperty('type', 'text');
+      expect(result.content[0].text).toContain('🧹 Cleared 1 conversation (1 message)');
+      expect(result.content[0].text).toContain('🦆 All ducks now have a fresh start!');
+      
+      // Verify conversations were actually cleared
+      expect(conversationManager.getConversation('test-1')).toBeUndefined();
+    });
+
+    it('should handle empty state gracefully', () => {
+      const result = clearConversationsTool(conversationManager, {});
+      
+      expect(result.content[0].text).toContain('🧹 No conversations to clear - memory is already empty!');
+      expect(result.content[0].text).toContain('🦆 All ducks now have a fresh start!');
+    });
+
+    it('should handle multiple conversations correctly', () => {
+      // Create multiple conversations with different message counts
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'Hello 1',
+        timestamp: new Date(),
+      });
+      conversationManager.addMessage('test-1', {
+        role: 'assistant' as const,
+        content: 'Hi 1',
+        timestamp: new Date(),
+      });
+
+      conversationManager.createConversation('test-2', 'groq');
+      conversationManager.addMessage('test-2', {
+        role: 'user' as const,
+        content: 'Hello 2',
+        timestamp: new Date(),
+      });
+
+      conversationManager.createConversation('test-3', 'gemini');
+      // No messages in test-3
+
+      const result = clearConversationsTool(conversationManager, {});
+      
+      expect(result.content[0].text).toContain('🧹 Cleared 3 conversations (3 messages)');
+      expect(result.content[0].text).toContain('🦆 All ducks now have a fresh start!');
+      
+      // Verify all conversations were cleared
+      expect(conversationManager.listConversations()).toHaveLength(0);
+    });
+
+    it('should handle singular vs plural correctly', () => {
+      // Test single conversation with single message
+      conversationManager.createConversation('test-1', 'openai');
+      conversationManager.addMessage('test-1', {
+        role: 'user' as const,
+        content: 'Hello',
+        timestamp: new Date(),
+      });
+
+      const result = clearConversationsTool(conversationManager, {});
+      
+      // Should use singular form
+      expect(result.content[0].text).toContain('🧹 Cleared 1 conversation (1 message)');
+      expect(result.content[0].text).not.toContain('conversations');
+      expect(result.content[0].text).not.toContain('messages)');
+    });
+
+    it('should handle args parameter (even though unused)', () => {
+      const args = { unused: 'parameter' };
+      
+      conversationManager.createConversation('test-1', 'openai');
+      const result = clearConversationsTool(conversationManager, args);
+      
+      expect(result).toHaveProperty('content');
+      expect(result.content[0].text).toContain('🧹 Cleared 1 conversation');
+    });
+
+    it('should return consistent response structure', () => {
+      const result = clearConversationsTool(conversationManager, {});
+      
+      // Verify response structure matches MCP tool format
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: expect.stringContaining('🧹'),
+          },
+        ],
+      });
+      
+      expect(result.content[0].text).toContain('🦆 All ducks now have a fresh start!');
+    });
+  });
+
+  describe('integration with ConversationManager', () => {
+    it('should properly clear all conversation state', () => {
+      // Create complex scenario
+      conversationManager.createConversation('debug-session', 'openai');
+      conversationManager.addMessage('debug-session', {
+        role: 'user' as const,
+        content: 'Help with bug',
+        timestamp: new Date(),
+      });
+      conversationManager.addMessage('debug-session', {
+        role: 'assistant' as const,
+        content: 'Sure, what\'s the issue?',
+        timestamp: new Date(),
+      });
+
+      conversationManager.createConversation('code-review', 'groq');
+      conversationManager.addMessage('code-review', {
+        role: 'user' as const,
+        content: 'Review this code',
+        timestamp: new Date(),
+      });
+
+      // Switch provider in second conversation
+      conversationManager.switchProvider('code-review', 'gemini');
+
+      // Verify setup
+      expect(conversationManager.listConversations()).toHaveLength(2);
+      expect(conversationManager.getConversation('debug-session')!.messages).toHaveLength(2);
+      expect(conversationManager.getConversation('code-review')!.messages).toHaveLength(2); // 1 + 1 system message
+
+      // Clear all
+      const result = clearConversationsTool(conversationManager, {});
+
+      // Verify complete cleanup
+      expect(conversationManager.listConversations()).toHaveLength(0);
+      expect(conversationManager.getConversation('debug-session')).toBeUndefined();
+      expect(conversationManager.getConversation('code-review')).toBeUndefined();
+      
+      // Verify counts in response
+      expect(result.content[0].text).toContain('🧹 Cleared 2 conversations (4 messages)');
+    });
+  });
+});


### PR DESCRIPTION
Add ability to clear all conversation history via new clear_conversations MCP tool:
- Add clearAll() method to ConversationManager
- Create clear_conversations tool with proper response formatting
- Register tool in server with schema definition
- Update README with tool documentation
- Add comprehensive tests (27 tests total, all passing)
- Handle edge cases like empty state and singular/plural messaging

This allows users to reset conversation context when needed for fresh starts.