### PR TITLE
chore: allowlist GHSA-8qq5-rm4j-mr97 (tar vuln in dev dep)

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -6,6 +6,7 @@
   "report-type": "summary",
   "allowlist": [
     "GHSA-5j98-mcp5-4vw2",
-    "GHSA-73rr-hh4g-fpgx"
+    "GHSA-73rr-hh4g-fpgx",
+    "GHSA-8qq5-rm4j-mr97"
   ]
 }


### PR DESCRIPTION
## Summary
- Allowlist high severity tar vulnerability (CVE-2026-23745) to fix CI audit failure
- Vulnerability is in tar <= 7.5.2, only affects dev/CI through semantic-release dependency
- npm filters Link/SymbolicLink entries during package extraction, so production risk is low

## Test plan
- [x] Verified `npx audit-ci --config audit-ci.json` passes locally