### PR TITLE
feat: add human-readable title to all MCP tools

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -202,6 +202,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'ask_duck',
       {
+        title: 'Ask a Duck',
         description: this.mcpEnabled
           ? 'Ask a question to a specific LLM provider (duck) with MCP tool access'
           : 'Ask a question to a specific LLM provider (duck)',
@@ -232,6 +233,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'chat_with_duck',
       {
+        title: 'Chat with a Duck',
         description: 'Have a conversation with a duck, maintaining context across messages',
         inputSchema: {
           conversation_id: z.string().describe('Conversation ID (creates new if not exists)'),
@@ -256,6 +258,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'clear_conversations',
       {
+        title: 'Clear Conversations',
         description: 'Clear all conversation history and start fresh',
         annotations: {
           destructiveHint: true,
@@ -276,6 +279,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'list_ducks',
       {
+        title: 'List Ducks',
         description: 'List all available LLM providers (ducks) and their status',
         inputSchema: {
           check_health: z.boolean().default(false).describe('Perform health check on all providers'),
@@ -298,6 +302,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'list_models',
       {
+        title: 'List Models',
         description: 'List available models for LLM providers',
         inputSchema: {
           provider: z.string().optional().describe('Provider name (optional, lists all if not specified)'),
@@ -322,6 +327,7 @@ export class RubberDuckServer {
       this.server,
       'compare_ducks',
       {
+        title: 'Compare Ducks',
         description: 'Ask the same question to multiple ducks simultaneously',
         inputSchema: {
           prompt: z.string().describe('The question to ask all ducks'),
@@ -351,6 +357,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'duck_council',
       {
+        title: 'Duck Council',
         description: 'Get responses from all configured ducks (like a panel discussion)',
         inputSchema: {
           prompt: z.string().describe('The question for the duck council'),
@@ -379,6 +386,7 @@ export class RubberDuckServer {
       this.server,
       'duck_vote',
       {
+        title: 'Duck Vote',
         description: 'Have multiple ducks vote on options with reasoning. Returns vote tally, confidence scores, and consensus level.',
         inputSchema: {
           question: z.string().describe('The question to vote on (e.g., "Best approach for error handling?")'),
@@ -406,6 +414,7 @@ export class RubberDuckServer {
     this.server.registerTool(
       'duck_judge',
       {
+        title: 'Duck Judge',
         description: 'Have one duck evaluate and rank other ducks\' responses. Use after duck_council to get a comparative evaluation.',
         inputSchema: {
           responses: z.array(z.object({
@@ -436,6 +445,7 @@ export class RubberDuckServer {
     this.server.experimental.tasks.registerToolTask(
       'duck_iterate',
       {
+        title: 'Duck Iteration',
         description: 'Iteratively refine a response between two ducks. One generates, the other critiques/improves, alternating for multiple rounds.',
         inputSchema: {
           prompt: z.string().describe('The initial prompt/task to iterate on'),
@@ -479,6 +489,7 @@ export class RubberDuckServer {
     this.server.experimental.tasks.registerToolTask(
       'duck_debate',
       {
+        title: 'Duck Debate',
         description: 'Structured multi-round debate between ducks. Supports oxford (pro/con), socratic (questioning), and adversarial (attack/defend) formats.',
         inputSchema: {
           prompt: z.string().describe('The debate topic or proposition'),
@@ -525,6 +536,7 @@ export class RubberDuckServer {
       this.server,
       'get_usage_stats',
       {
+        title: 'Usage Statistics',
         description: 'Get usage statistics for a time period. Shows token counts and costs (when pricing configured).',
         inputSchema: {
           period: z.enum(['today', '7d', '30d', 'all']).default('today').describe('Time period for stats'),
@@ -550,6 +562,7 @@ export class RubberDuckServer {
       this.server.registerTool(
         'get_pending_approvals',
         {
+          title: 'Pending Approvals',
           description: 'Get list of pending MCP tool approvals from ducks',
           inputSchema: {
             duck: z.string().optional().describe('Filter by duck name (optional)'),
@@ -575,6 +588,7 @@ export class RubberDuckServer {
       this.server.registerTool(
         'approve_mcp_request',
         {
+          title: 'Approve MCP Request',
           description: "Approve or deny a duck's MCP tool request",
           inputSchema: {
             approval_id: z.string().describe('The approval request ID'),
@@ -602,6 +616,7 @@ export class RubberDuckServer {
       this.server.registerTool(
         'mcp_status',
         {
+          title: 'MCP Bridge Status',
           description: 'Get status of MCP bridge, servers, and pending approvals',
           annotations: {
             readOnlyHint: true,

--- a/tests/tool-annotations.test.ts
+++ b/tests/tool-annotations.test.ts
@@ -75,6 +75,77 @@ describe('Tool Annotations', () => {
     });
   });
 
+  describe('Tool Titles', () => {
+    /**
+     * Tool titles provide human-readable display names for MCP clients.
+     * According to MCP spec (2025-11-25), title is optional but recommended
+     * for better UX in tool pickers and UI displays.
+     *
+     * Test logic:
+     * - Every tool SHOULD have a title for consistent UX
+     * - Titles should be human-readable (not machine identifiers)
+     * - Titles should be non-empty strings
+     * - Titles should be unique to avoid UI confusion
+     */
+
+    it('every tool should have a title', () => {
+      for (const tool of tools) {
+        expect(tool.title).toBeDefined();
+        expect(typeof tool.title).toBe('string');
+        expect(tool.title!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('titles should be human-readable (contain spaces or be single words)', () => {
+      // Machine identifiers use underscores (ask_duck), titles should not
+      for (const tool of tools) {
+        expect(tool.title).not.toContain('_');
+      }
+    });
+
+    it('titles should be unique across all tools', () => {
+      const titles = tools.map((t) => t.title);
+      const uniqueTitles = new Set(titles);
+      expect(uniqueTitles.size).toBe(titles.length);
+    });
+
+    it('titles should start with an uppercase letter (Title Case)', () => {
+      for (const tool of tools) {
+        const firstChar = tool.title!.charAt(0);
+        expect(firstChar).toBe(firstChar.toUpperCase());
+      }
+    });
+
+    it('titles should be reasonably short for UI display (under 30 chars)', () => {
+      for (const tool of tools) {
+        expect(tool.title!.length).toBeLessThanOrEqual(30);
+      }
+    });
+
+    // Specific title tests to ensure correct mapping
+    const expectedTitles: Record<string, string> = {
+      ask_duck: 'Ask a Duck',
+      chat_with_duck: 'Chat with a Duck',
+      clear_conversations: 'Clear Conversations',
+      list_ducks: 'List Ducks',
+      list_models: 'List Models',
+      compare_ducks: 'Compare Ducks',
+      duck_council: 'Duck Council',
+      duck_vote: 'Duck Vote',
+      duck_judge: 'Duck Judge',
+      duck_iterate: 'Duck Iteration',
+      duck_debate: 'Duck Debate',
+      get_usage_stats: 'Usage Statistics',
+    };
+
+    for (const [toolName, expectedTitle] of Object.entries(expectedTitles)) {
+      it(`${toolName} should have title "${expectedTitle}"`, () => {
+        const tool = findTool(toolName);
+        expect(tool?.title).toBe(expectedTitle);
+      });
+    }
+  });
+
   describe('ask_duck', () => {
     /**
      * ask_duck queries an external LLM API and returns a response.
@@ -650,6 +721,45 @@ describe('MCP-specific Tool Annotations', () => {
     it('should be marked as open-world', () => {
       const tool = findTool('mcp_status');
       expect(tool?.annotations?.openWorldHint).toBe(true);
+    });
+  });
+
+  describe('MCP Tool Titles', () => {
+    /**
+     * Verify that MCP-specific tools also have proper human-readable titles.
+     */
+
+    it('all MCP tools should have titles', () => {
+      const mcpTools = ['get_pending_approvals', 'approve_mcp_request', 'mcp_status'];
+      for (const toolName of mcpTools) {
+        const tool = findTool(toolName);
+        expect(tool?.title).toBeDefined();
+        expect(typeof tool?.title).toBe('string');
+        expect(tool?.title!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('get_pending_approvals should have title "Pending Approvals"', () => {
+      const tool = findTool('get_pending_approvals');
+      expect(tool?.title).toBe('Pending Approvals');
+    });
+
+    it('approve_mcp_request should have title "Approve MCP Request"', () => {
+      const tool = findTool('approve_mcp_request');
+      expect(tool?.title).toBe('Approve MCP Request');
+    });
+
+    it('mcp_status should have title "MCP Bridge Status"', () => {
+      const tool = findTool('mcp_status');
+      expect(tool?.title).toBe('MCP Bridge Status');
+    });
+
+    it('MCP tool titles should not contain underscores', () => {
+      const mcpTools = ['get_pending_approvals', 'approve_mcp_request', 'mcp_status'];
+      for (const toolName of mcpTools) {
+        const tool = findTool(toolName);
+        expect(tool?.title).not.toContain('_');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `title` field to all 15 MCP tool definitions per MCP spec (2025-11-25)
- Titles improve UX in MCP client tool pickers and UI displays
- Add comprehensive tests for title validation

## Tool Titles

| Tool | Title |
|------|-------|
| `ask_duck` | Ask a Duck |
| `chat_with_duck` | Chat with a Duck |
| `clear_conversations` | Clear Conversations |
| `list_ducks` | List Ducks |
| `list_models` | List Models |
| `compare_ducks` | Compare Ducks |
| `duck_council` | Duck Council |
| `duck_vote` | Duck Vote |
| `duck_judge` | Duck Judge |
| `duck_iterate` | Duck Iteration |
| `duck_debate` | Duck Debate |
| `get_usage_stats` | Usage Statistics |
| `get_pending_approvals` | Pending Approvals |
| `approve_mcp_request` | Approve MCP Request |
| `mcp_status` | MCP Bridge Status |

## Test plan

- [x] All 1059 existing tests pass
- [x] New title tests verify: presence, uniqueness, format, correct mapping
- [x] TypeScript compilation passes
- [x] Lint passes
- [x] Verified titles returned via MCP protocol

Closes #54