### PR TITLE
chore: update MCP Registry listing to v1.14.3

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,49 +1,42 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nesquikm/rubber-duck",
-  "description": "An MCP server that bridges to multiple OpenAI-compatible LLMs - your AI rubber duck debugging panel",
-  "status": "active",
+  "description": "Bridge to multiple LLMs and CLI agents: councils, debates, voting, and more",
   "repository": {
     "url": "https://github.com/nesquikm/mcp-rubber-duck",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "1.14.3",
   "packages": [
     {
-      "registry_type": "npm",
-      "registry_base_url": "https://registry.npmjs.org",
+      "registryType": "npm",
       "identifier": "mcp-rubber-duck",
-      "version": "1.1.1",
+      "version": "1.14.3",
       "transport": {
         "type": "stdio"
       },
-      "environment_variables": [
+      "environmentVariables": [
         {
           "description": "OpenAI API key (starts with sk-)",
-          "is_required": false,
           "format": "string",
-          "is_secret": true,
+          "isSecret": true,
           "name": "OPENAI_API_KEY"
         },
         {
           "description": "Google Gemini API key",
-          "is_required": false,
           "format": "string",
-          "is_secret": true,
+          "isSecret": true,
           "name": "GEMINI_API_KEY"
         },
         {
           "description": "Groq API key (starts with gsk_)",
-          "is_required": false,
           "format": "string",
-          "is_secret": true,
+          "isSecret": true,
           "name": "GROQ_API_KEY"
         },
         {
           "description": "Default LLM provider to use",
-          "is_required": false,
           "format": "string",
-          "is_secret": false,
           "name": "DEFAULT_PROVIDER"
         }
       ]


### PR DESCRIPTION
## Summary
- Update `server.json` from v1.1.1 to v1.14.3
- Migrate to latest registry schema (`2025-12-11`)
- Update field names from snake_case to camelCase (matching current registry API)
- Update description to reflect current feature set

## Note
`chore:` commit — no version bump will be triggered.

The registry listing will be updated separately via `mcp-publisher publish`.