### PR TITLE
fix: update audit-ci allowlist for minimatch ReDoS advisories

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -5,6 +5,7 @@
   "critical": true,
   "report-type": "summary",
   "allowlist": [
-    "GHSA-3ppc-4f35-3m26"
+    "GHSA-23c5-xmqv-rm74",
+    "GHSA-7r86-cg39-jmmj"
   ]
 }


### PR DESCRIPTION
## Summary

- Removes stale allowlist entry `GHSA-3ppc-4f35-3m26` (already fixed upstream; CI was warning about it)
- Adds `GHSA-23c5-xmqv-rm74` and `GHSA-7r86-cg39-jmmj` — two `minimatch` ReDoS vulnerabilities in the `semantic-release → @semantic-release/npm → npm → minimatch` chain

## Why allowlist instead of fix?

`npm` bundles its own `minimatch` internally, so npm overrides can't reach it. The only fix `npm audit` suggests is a breaking downgrade of `@semantic-release/npm`. Both advisories are ReDoS vulnerabilities in dev-only CI tooling — semantic-release never processes untrusted glob input, so the risk is negligible.

## Test plan

- [ ] CI `📦 Dependency Check` job passes (was failing with 4 high vulnerabilities)
- [ ] CI `🔒 Security Scan` and `🧪 Test Suite` jobs unaffected