### PR TITLE
fix: resolve all security vulnerabilities in dependencies

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -4,9 +4,5 @@
   "high": true,
   "critical": true,
   "report-type": "summary",
-  "allowlist": [
-    "GHSA-23c5-xmqv-rm74",
-    "GHSA-7r86-cg39-jmmj",
-    "GHSA-qffp-2rhf-9h96"
-  ]
+  "allowlist": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-rubber-duck",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-rubber-duck",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.1",
@@ -5707,9 +5707,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6122,9 +6122,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7961,9 +7961,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.0.tgz",
-      "integrity": "sha512-82gRxKrh/eY5UnNorkTFcdBQAGpgjWehkfGVqAGlJjejEtJZGGJUqjo3mbBTNbc5BTnPKGVtGPBZGhElujX5cw==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
+      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -8041,7 +8041,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/config": "^10.7.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
@@ -8049,7 +8049,7 @@
         "@npmcli/package-json": "^7.0.5",
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.3",
+        "@npmcli/run-script": "^10.0.4",
         "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
@@ -8066,17 +8066,17 @@
         "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.3",
-        "libnpmexec": "^10.2.3",
-        "libnpmfund": "^7.0.17",
+        "libnpmdiff": "^8.1.4",
+        "libnpmexec": "^10.2.4",
+        "libnpmfund": "^7.0.18",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.3",
+        "libnpmpack": "^9.1.4",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
         "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.2",
+        "minimatch": "^10.2.4",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -8090,7 +8090,7 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.4.0",
+        "pacote": "^21.5.0",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
@@ -8099,7 +8099,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.9",
+        "tar": "^7.5.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -8178,10 +8178,11 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.0",
+      "version": "9.4.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -8378,7 +8379,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.3",
+      "version": "10.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8386,8 +8387,7 @@
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0",
-        "which": "^6.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8542,7 +8542,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8896,11 +8896,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.3",
+      "version": "8.1.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -8914,12 +8914,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.3",
+      "version": "10.2.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -8936,11 +8936,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.17",
+      "version": "7.0.18",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.0"
+        "@npmcli/arborist": "^9.4.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8959,11 +8959,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.3",
+      "version": "9.1.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -9058,7 +9058,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.2",
+      "version": "10.2.4",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9368,7 +9368,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.4.0",
+      "version": "21.5.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9647,7 +9647,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.9",
+      "version": "7.5.11",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9792,11 +9792,10 @@
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -11272,9 +11271,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -12521,9 +12520,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Summary
- Update undici, hono, flatted, tar and other transitive deps via `npm audit fix` to resolve all 6 known vulnerabilities (5 high, 1 moderate)
- Clean up `audit-ci.json` allowlist — all previously allowlisted advisories (GHSA-23c5-xmqv-rm74, GHSA-7r86-cg39-jmmj, GHSA-qffp-2rhf-9h96) are no longer needed
- Fixes the failing CI security audit on master

Supersedes #82, #83, #85

## Fixed advisories
- GHSA-f269-vfmq-vjvj (undici - WebSocket overflow)
- GHSA-2mjp-6q6p-2qxm (undici - HTTP smuggling)
- GHSA-vrm6-8vpv-qv8q (undici - WebSocket memory)
- GHSA-v9p9-hfj2-hcw8 (undici - WebSocket exception)
- GHSA-4992-7rv2-5pvq (undici - CRLF injection)
- GHSA-phc3-fgpg-7m6h (undici - DoS via buffering)
- GHSA-v8w9-8mx6-g223 (hono)
- GHSA-25h7-pfq9-p65f (flatted)
- GHSA-9ppj-qmqm-q256 (tar)

## Test plan
- [x] `npm audit` — 0 vulnerabilities
- [x] `npx audit-ci --config audit-ci.json` — passed
- [x] All 1070 tests pass
- [x] Build succeeds