### PR TITLE
feat: add outputSchema and structuredContent to structured tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ An MCP (Model Context Protocol) server that acts as a bridge to query multiple L
 - **Granular Security** -- Per-server approval controls with session-based approvals
 - **Interactive UIs** -- Rich HTML panels for compare, vote, debate, and usage tools (via [MCP Apps](https://github.com/modelcontextprotocol/ext-apps))
 - **Tool Annotations** -- MCP-compliant hints for tool behavior (read-only, destructive, etc.)
+- **Structured Output** -- `outputSchema` on tools returning structured JSON for client-side validation (Cursor, VS Code/Copilot)
 
 ## Supported Providers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
   <img src="../assets/docs-roadmap.jpg" alt="Roadmap planning wall" width="600">
 </p>
 
-*Last updated: March 2026*
+*Last updated: April 2026*
 
 ## Recommended Feature Priority
 
@@ -14,8 +14,8 @@
 |---|---------|-------|--------|--------|
 | 1 | ~~Multimodal - Vision input~~ ✅ | [#76](https://github.com/nesquikm/mcp-rubber-duck/issues/76) | Medium-High | Medium |
 | 1b | Multimodal MCP Bridge - image tool results | [#78](https://github.com/nesquikm/mcp-rubber-duck/issues/78) | Medium | Medium |
-| 1c | Image URL support in multimodal input | [#87](https://github.com/nesquikm/mcp-rubber-duck/issues/87) | Medium | Low |
-| 2 | outputSchema for voting/consensus tools | [#53](https://github.com/nesquikm/mcp-rubber-duck/issues/53) | High | Low-Medium |
+| 1c | ~~Image URL support in multimodal input~~ ✅ | [#87](https://github.com/nesquikm/mcp-rubber-duck/issues/87) | Medium | Low |
+| 2 | ~~outputSchema for voting/consensus tools~~ ✅ | [#53](https://github.com/nesquikm/mcp-rubber-duck/issues/53) | High | Low-Medium |
 | 3 | ~~Multi-round tool calling loop~~ ✅ | [#69](https://github.com/nesquikm/mcp-rubber-duck/issues/69) | High | Medium |
 | 4 | Streamable HTTP transport + Streaming responses | [#57](https://github.com/nesquikm/mcp-rubber-duck/issues/57), [#47](https://github.com/nesquikm/mcp-rubber-duck/issues/47) | High | Medium |
 | 5 | MCP Resources + resource_link | [#48](https://github.com/nesquikm/mcp-rubber-duck/issues/48), [#56](https://github.com/nesquikm/mcp-rubber-duck/issues/56) | Medium-High | Medium |
@@ -44,7 +44,7 @@
 
 ## Suggested Phases
 
-- **Phase 1** (Foundation): outputSchema (#53) → Multi-round tool calling (#69) → Streamable HTTP (#57) + Streaming (#47)
+- **Phase 1** (Foundation): ~~outputSchema (#53)~~ → ~~Multi-round tool calling (#69)~~ → Streamable HTTP (#57) + Streaming (#47)
 - **Phase 2** (Differentiation): Duck Hypothesis (#45) + Duck Calibrate (#40) + Duck Deliberate (#35)
 - **Phase 3** (Platform): Resources (#48) + Smart Router (#10) + Fallback Chains (#20)
 - **Phase 4** (Agentic): Duck Autopilot (#12)
@@ -57,7 +57,7 @@
 | Streaming / Progress | Done | `ProgressReporter` via MCP `notifications/progress` |
 | Async / Tasks | Done | MCP experimental tasks API with cancellation |
 | Multimodal Vision | Done | Image input for ask_duck, chat_with_duck, compare_ducks, duck_council (#76) |
-| Structured output | Partial | Dual-content workaround, no formal `outputSchema` → #53 |
+| Structured output | Done | `outputSchema` on compare_ducks, duck_vote, duck_debate, get_usage_stats (#53) |
 
 ## Client Support Matrix
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.1",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@semantic-release/npm": "^13.1.3",
         "ajv": "^8.17.1",
         "dotenv": "^16.4.0",
@@ -1750,9 +1750,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.0.1",
-    "@modelcontextprotocol/sdk": "^1.24.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@semantic-release/npm": "^13.1.3",
     "ajv": "^8.17.1",
     "dotenv": "^16.4.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,6 +201,7 @@ export class RubberDuckServer {
   // This helper narrows the type to satisfy McpServer's CallToolResult expectation.
   private toolResult(result: {
     content: { type: string; text: string }[];
+    structuredContent?: Record<string, unknown>;
     isError?: boolean;
   }): CallToolResult {
     return result as CallToolResult;
@@ -413,6 +414,25 @@ export class RubberDuckServer {
             .optional()
             .describe('Optional images to include with the prompt (for vision-capable models)'),
         },
+        outputSchema: {
+          responses: z.array(
+            z.object({
+              provider: z.string(),
+              nickname: z.string(),
+              model: z.string(),
+              content: z.string(),
+              latency: z.number(),
+              tokens: z
+                .object({
+                  prompt: z.number(),
+                  completion: z.number(),
+                  total: z.number(),
+                })
+                .nullable(),
+              error: z.string().optional(),
+            })
+          ),
+        },
         annotations: {
           readOnlyHint: true,
           openWorldHint: true,
@@ -503,6 +523,26 @@ export class RubberDuckServer {
             .boolean()
             .default(true)
             .describe('Require ducks to explain their vote (default: true)'),
+        },
+        outputSchema: {
+          question: z.string(),
+          options: z.array(z.string()),
+          winner: z.string().nullable(),
+          isTie: z.boolean(),
+          tally: z.record(z.string(), z.number()),
+          confidenceByOption: z.record(z.string(), z.number()),
+          votes: z.array(
+            z.object({
+              voter: z.string(),
+              nickname: z.string(),
+              choice: z.string(),
+              confidence: z.number(),
+              reasoning: z.string(),
+            })
+          ),
+          totalVoters: z.number(),
+          validVotes: z.number(),
+          consensusLevel: z.enum(['unanimous', 'majority', 'plurality', 'split', 'none']),
         },
         annotations: {
           readOnlyHint: true,
@@ -669,6 +709,31 @@ export class RubberDuckServer {
             .optional()
             .describe('Provider to synthesize the debate (optional, uses first provider)'),
         },
+        outputSchema: {
+          topic: z.string(),
+          format: z.enum(['oxford', 'socratic', 'adversarial']),
+          totalRounds: z.number(),
+          participants: z.array(
+            z.object({
+              provider: z.string(),
+              nickname: z.string(),
+              position: z.enum(['pro', 'con', 'neutral']),
+            })
+          ),
+          rounds: z.array(
+            z.array(
+              z.object({
+                round: z.number(),
+                provider: z.string(),
+                nickname: z.string(),
+                position: z.enum(['pro', 'con', 'neutral']),
+                content: z.string(),
+              })
+            )
+          ),
+          synthesis: z.string(),
+          synthesizer: z.string(),
+        },
         annotations: {
           readOnlyHint: true,
           openWorldHint: true,
@@ -723,6 +788,33 @@ export class RubberDuckServer {
             .enum(['today', '7d', '30d', 'all'])
             .default('today')
             .describe('Time period for stats'),
+        },
+        outputSchema: {
+          period: z.string(),
+          startDate: z.string(),
+          endDate: z.string(),
+          totals: z.object({
+            requests: z.number(),
+            promptTokens: z.number(),
+            completionTokens: z.number(),
+            errors: z.number(),
+            estimatedCostUSD: z.number().optional(),
+          }),
+          usage: z.record(
+            z.string(),
+            z.record(
+              z.string(),
+              z.object({
+                requests: z.number(),
+                promptTokens: z.number(),
+                completionTokens: z.number(),
+                errors: z.number(),
+              })
+            )
+          ),
+          costByProvider: z
+            .record(z.string(), z.number())
+            .optional(),
         },
         annotations: {
           readOnlyHint: true,
@@ -1004,7 +1096,7 @@ export class RubberDuckServer {
             total: r.usage.total_tokens,
           }
         : null,
-      error: r.content.startsWith('Error:') ? r.content : undefined,
+      ...(r.content.startsWith('Error:') && { error: r.content }),
     }));
 
     return {
@@ -1018,6 +1110,7 @@ export class RubberDuckServer {
           text: JSON.stringify(structuredData),
         },
       ],
+      structuredContent: { responses: structuredData },
     };
   }
 

--- a/src/tools/compare-ducks.ts
+++ b/src/tools/compare-ducks.ts
@@ -85,7 +85,7 @@ export async function compareDucksTool(
           total: r.usage.total_tokens,
         }
       : null,
-    error: r.content.startsWith('Error:') ? r.content : undefined,
+    ...(r.content.startsWith('Error:') && { error: r.content }),
   }));
 
   return {
@@ -99,5 +99,6 @@ export async function compareDucksTool(
         text: JSON.stringify(structuredData),
       },
     ],
+    structuredContent: { responses: structuredData },
   };
 }

--- a/src/tools/duck-debate.ts
+++ b/src/tools/duck-debate.ts
@@ -188,6 +188,7 @@ export async function duckDebateTool(
         text: JSON.stringify(structuredData),
       },
     ],
+    structuredContent: structuredData,
   };
 }
 

--- a/src/tools/duck-vote.ts
+++ b/src/tools/duck-vote.ts
@@ -107,5 +107,6 @@ export async function duckVoteTool(
         text: JSON.stringify(structuredData),
       },
     ],
+    structuredContent: structuredData,
   };
 }

--- a/src/tools/get-usage-stats.ts
+++ b/src/tools/get-usage-stats.ts
@@ -89,6 +89,7 @@ export function getUsageStatsTool(usageService: UsageService, args: Record<strin
         text: JSON.stringify(structuredData),
       },
     ],
+    structuredContent: structuredData,
   };
 }
 

--- a/tests/tool-annotations.test.ts
+++ b/tests/tool-annotations.test.ts
@@ -442,6 +442,101 @@ describe('Tool Annotations', () => {
     });
   });
 
+  describe('Output Schemas', () => {
+    /**
+     * Tools that return structured JSON data should declare an outputSchema
+     * so clients can validate and understand the response format.
+     *
+     * Tools WITH outputSchema (return structured JSON in second content item):
+     * - compare_ducks, duck_vote, duck_debate, get_usage_stats
+     *
+     * Tools WITHOUT outputSchema (return only formatted text):
+     * - ask_duck, chat_with_duck, clear_conversations, list_ducks, list_models,
+     *   duck_council, duck_judge, duck_iterate
+     */
+
+    const toolsWithOutputSchema = [
+      'compare_ducks',
+      'duck_vote',
+      'duck_debate',
+      'get_usage_stats',
+    ];
+
+    const toolsWithoutOutputSchema = [
+      'ask_duck',
+      'chat_with_duck',
+      'clear_conversations',
+      'list_ducks',
+      'list_models',
+      'duck_council',
+      'duck_judge',
+      'duck_iterate',
+    ];
+
+    for (const toolName of toolsWithOutputSchema) {
+      it(`${toolName} should have an outputSchema`, () => {
+        const tool = findTool(toolName);
+        expect(tool?.outputSchema).toBeDefined();
+        expect(tool?.outputSchema?.type).toBe('object');
+      });
+    }
+
+    for (const toolName of toolsWithoutOutputSchema) {
+      it(`${toolName} should NOT have an outputSchema`, () => {
+        const tool = findTool(toolName);
+        expect(tool?.outputSchema).toBeUndefined();
+      });
+    }
+
+    it('compare_ducks outputSchema should describe response array', () => {
+      const tool = findTool('compare_ducks');
+      const schema = tool?.outputSchema as Record<string, unknown>;
+      const props = schema?.properties as Record<string, unknown>;
+      expect(props).toHaveProperty('responses');
+    });
+
+    it('duck_vote outputSchema should describe all vote result fields', () => {
+      const tool = findTool('duck_vote');
+      const schema = tool?.outputSchema as Record<string, unknown>;
+      const props = schema?.properties as Record<string, unknown>;
+      expect(props).toHaveProperty('question');
+      expect(props).toHaveProperty('options');
+      expect(props).toHaveProperty('winner');
+      expect(props).toHaveProperty('isTie');
+      expect(props).toHaveProperty('tally');
+      expect(props).toHaveProperty('confidenceByOption');
+      expect(props).toHaveProperty('votes');
+      expect(props).toHaveProperty('totalVoters');
+      expect(props).toHaveProperty('validVotes');
+      expect(props).toHaveProperty('consensusLevel');
+    });
+
+    it('duck_debate outputSchema should describe all debate result fields', () => {
+      const tool = findTool('duck_debate');
+      const schema = tool?.outputSchema as Record<string, unknown>;
+      const props = schema?.properties as Record<string, unknown>;
+      expect(props).toHaveProperty('topic');
+      expect(props).toHaveProperty('format');
+      expect(props).toHaveProperty('totalRounds');
+      expect(props).toHaveProperty('participants');
+      expect(props).toHaveProperty('rounds');
+      expect(props).toHaveProperty('synthesis');
+      expect(props).toHaveProperty('synthesizer');
+    });
+
+    it('get_usage_stats outputSchema should describe all usage data fields', () => {
+      const tool = findTool('get_usage_stats');
+      const schema = tool?.outputSchema as Record<string, unknown>;
+      const props = schema?.properties as Record<string, unknown>;
+      expect(props).toHaveProperty('period');
+      expect(props).toHaveProperty('startDate');
+      expect(props).toHaveProperty('endDate');
+      expect(props).toHaveProperty('totals');
+      expect(props).toHaveProperty('usage');
+      expect(props).toHaveProperty('costByProvider');
+    });
+  });
+
   describe('Base tools count', () => {
     it('should have exactly 12 base tools', () => {
       expect(tools).toHaveLength(12);


### PR DESCRIPTION
## Summary

Closes #53.

- Add MCP-compliant `outputSchema` (via Zod) to `compare_ducks`, `duck_vote`, `duck_debate`, and `get_usage_stats` — clients like Cursor and VS Code/Copilot can now validate structured responses
- Return `structuredContent` alongside existing text `content` in all four tools
- Bump `@modelcontextprotocol/sdk` from `^1.24.0` to `^1.29.0` for `outputSchema` support
- Add comprehensive outputSchema test coverage (schema presence, all property assertions)
- Update README feature list and roadmap (mark #53 done)

## Test plan

- [x] `npm run build` succeeds
- [x] All 1093 tests pass (`npm test`)
- [x] Manually tested all four tools via MCP — verified `structuredContent` matches declared schemas
- [x] Verified `error` field is correctly absent (not `undefined`) in `compare_ducks` when no errors