### PR TITLE
fix: update LLM pricing data (2026-04-19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-rubber-duck",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-rubber-duck",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.1",
@@ -6122,9 +6122,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/data/default-pricing.ts
+++ b/src/data/default-pricing.ts
@@ -3,7 +3,7 @@ import { PricingConfig } from '../config/types.js';
 /**
  * Default pricing data for common LLM providers.
  * Prices are in USD per million tokens.
- * Last updated: 2026-04-11
+ * Last updated: 2026-04-19
  *
  * To update pricing:
  * 1. Research current pricing from provider websites
@@ -14,7 +14,7 @@ import { PricingConfig } from '../config/types.js';
  * Users can override these defaults in their config.json file.
  */
 export const DEFAULT_PRICING_VERSION = 2;
-export const DEFAULT_PRICING_LAST_UPDATED = '2026-04-11';
+export const DEFAULT_PRICING_LAST_UPDATED = '2026-04-19';
 
 export const DEFAULT_PRICING: PricingConfig = {
   openai: {
@@ -94,6 +94,9 @@ export const DEFAULT_PRICING: PricingConfig = {
   },
 
   anthropic: {
+    // Claude 4.7 models (current flagship, April 2026)
+    'claude-opus-4-7': { inputPricePerMillion: 5, outputPricePerMillion: 25 },
+
     // Claude 4.6 models
     'claude-opus-4-6': { inputPricePerMillion: 5, outputPricePerMillion: 25 },
     'claude-sonnet-4-6': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
@@ -247,14 +250,18 @@ export const DEFAULT_PRICING: PricingConfig = {
     'mistral-medium-3': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
 
     // Mistral Small 3.2
-    'mistral-small-latest': { inputPricePerMillion: 0.06, outputPricePerMillion: 0.18 },
-    'mistral-small-3.2': { inputPricePerMillion: 0.06, outputPricePerMillion: 0.18 },
-    'mistral-small-3.1': { inputPricePerMillion: 0.03, outputPricePerMillion: 0.11 },
+    'mistral-small-latest': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.2 },
+    'mistral-small-3.2': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.2 },
+    'mistral-small-3.1': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
+    'mistral-small-2501': { inputPricePerMillion: 0.05, outputPricePerMillion: 0.08 },
     'mistral-small-2409': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
     'mistral-small-3': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
 
     // Mistral Saba
     'mistral-saba': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.6 },
+
+    // Magistral (reasoning)
+    'magistral-medium': { inputPricePerMillion: 2, outputPricePerMillion: 5 },
 
     // Codestral
     'codestral-latest': { inputPricePerMillion: 0.3, outputPricePerMillion: 0.9 },
@@ -265,10 +272,11 @@ export const DEFAULT_PRICING: PricingConfig = {
     'codestral-embed': { inputPricePerMillion: 0.15, outputPricePerMillion: 0 },
 
     // Devstral 2
-    'devstral-2': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
-    'devstral-2512': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
+    'devstral-2': { inputPricePerMillion: 0.4, outputPricePerMillion: 0.9 },
+    'devstral-2512': { inputPricePerMillion: 0.4, outputPricePerMillion: 0.9 },
     'devstral-medium': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
     'devstral-small-2': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
+    'devstral-small-1.1': { inputPricePerMillion: 0.07, outputPricePerMillion: 0.28 },
 
     // Ministral
     'ministral-14b-2512': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.2 },
@@ -279,14 +287,24 @@ export const DEFAULT_PRICING: PricingConfig = {
 
     // Pixtral
     'pixtral-large-latest': { inputPricePerMillion: 2, outputPricePerMillion: 6 },
+    'pixtral-large-2411': { inputPricePerMillion: 2, outputPricePerMillion: 6 },
+    'pixtral-12b': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.1 },
+
+    // Voxtral
+    'voxtral-small-2507': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
+
+    // Mixtral
+    'open-mixtral-8x7b': { inputPricePerMillion: 0.24, outputPricePerMillion: 0.24 },
+    'open-mixtral-8x22b': { inputPricePerMillion: 1.2, outputPricePerMillion: 1.2 },
 
     // Open models
-    'open-mistral-nemo': { inputPricePerMillion: 0.02, outputPricePerMillion: 0.02 },
+    'open-mistral-nemo': { inputPricePerMillion: 0.02, outputPricePerMillion: 0.04 },
   },
 
   together: {
     // Current serverless lineup (April 2026)
     'MiniMaxAI/MiniMax-M2.5': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
+    'MiniMaxAI/MiniMax-M2.7': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
     'moonshotai/Kimi-K2.5': { inputPricePerMillion: 0.5, outputPricePerMillion: 2.8 },
     'zai-org/GLM-5.1': { inputPricePerMillion: 1.4, outputPricePerMillion: 4.4 },
     'zai-org/GLM-5': { inputPricePerMillion: 1, outputPricePerMillion: 3.2 },


### PR DESCRIPTION
## Summary
- Refreshed default LLM pricing as of 2026-04-19
- Added `claude-opus-4-7` (Anthropic flagship)
- Mistral: corrected 4 prices, added 8 newly listed models
- Added `MiniMaxAI/MiniMax-M2.7` (Together AI)

## Changes by provider
- **Anthropic:** +`claude-opus-4-7` ($5/$25 per MTok)
- **Mistral:** Updated `mistral-small-latest`, `mistral-small-3.1`, `open-mistral-nemo`, `devstral-2`/`devstral-2512`. Added `mistral-small-2501`, `magistral-medium`, `devstral-small-1.1`, `pixtral-large-2411`, `pixtral-12b`, `voxtral-small-2507`, `open-mixtral-8x7b`, `open-mixtral-8x22b`
- **Together AI:** +`MiniMaxAI/MiniMax-M2.7` ($0.30/$1.20)
- **OpenAI / Google / Groq / DeepSeek:** verified, no changes

## Test plan
- [x] `npm run typecheck`
- [x] `npm test -- tests/pricing.test.ts` (31/31)
- [x] `npm run lint`