### PR TITLE
docs: spec-aligned positioning + what's-next roadmap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ An MCP (Model Context Protocol) server that acts as a bridge to query multiple L
   <img src="assets/mcp-rubber-duck.jpg" alt="MCP Rubber Duck - AI ducks helping debug code" width="600">
 </p>
 
+> **Why direct provider integration?** MCP's `sampling` primitive -- a server borrowing the *host's* model -- was deprecated in the [2026-07-28 spec RC](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577) in favor of servers integrating directly with LLM provider APIs. Rubber Duck has always worked this way (it brings its own ducks), so it's aligned with where the protocol is heading -- no migration required.
+
 ## Features
 
 - **Universal OpenAI Compatibility** -- Works with any OpenAI-compatible API endpoint
@@ -32,6 +34,7 @@ An MCP (Model Context Protocol) server that acts as a bridge to query multiple L
 - **Interactive UIs** -- Rich HTML panels for compare, vote, debate, and usage tools (via [MCP Apps](https://github.com/modelcontextprotocol/ext-apps))
 - **Tool Annotations** -- MCP-compliant hints for tool behavior (read-only, destructive, etc.)
 - **Structured Output** -- `outputSchema` on tools returning structured JSON for client-side validation (Cursor, VS Code/Copilot)
+- **Spec-Aligned by Design** -- connects directly to provider APIs, the path the MCP `2026-07-28` spec recommends now that server-side `sampling` is deprecated ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577))
 
 ## Supported Providers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,26 @@
   <img src="../assets/docs-roadmap.jpg" alt="Roadmap planning wall" width="600">
 </p>
 
-*Last updated: April 2026*
+*Last updated: June 2026*
+
+## Next Up (June 2026 research)
+
+A multi-agent research pass (codebase audit + MCP-spec frontier + competitive landscape + 2025–26 LLM literature) produced these picks:
+
+1. **Debiased `duck_judge` Panel** ([#119](https://github.com/nesquikm/mcp-rubber-duck/issues/119)) — *top pick.* Harden the least-developed consensus tool into a multi-provider judge panel: position-bias swap-and-average, criterion-separated rubric, Borda/mean-rank across heterogeneous judges, agreement-derived confidence, and the `outputSchema` it currently lacks. Lands on the project's structural moat (a judge can't cancel its own bias; inter-judge agreement needs multiple providers). Medium effort, client-agnostic, ships on STDIO today.
+2. **Streamable HTTP transport** ([#57](https://github.com/nesquikm/mcp-rubber-duck/issues/57)) — *top strategic lever.* The 2026-07-28 MCP RC pivots to a stateless core; HTTP is now the single biggest reach gap and the prerequisite for Server Cards (#49/#98/#101) and hosted/multi-tenant deployment. Elevate above the cognitive Duck-X tools.
+3. **`duck_check` cross-vendor action gate** ([#120](https://github.com/nesquikm/mcp-rubber-duck/issues/120)) — best genuinely-new idea. An agent-facing GO/BLOCK/ASK-HUMAN gate for risky actions; `dissent_ratio` is only meaningful across vendors. Pair with #40 so the shared cross-model disagreement signal is built once.
+
+### Positioning: aligned with the post-Sampling spec direction
+
+The 2026-07-28 MCP RC ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577), merged 2026-05-15 — annotation-only, 12-month window) deprecates **Sampling** (the primitive that let a server borrow the host's model) and points servers needing model access toward **direct integration with LLM provider APIs**. That is exactly what Rubber Duck does: it brings its own provider connections rather than depending on host Sampling. The project is already aligned with the spec's recommended direction — worth stating explicitly in the README and registry card. (Caveat: annotation-only, and reviewers noted sampling may return in a more flexible form — frame as "aligned with," not "official replacement.")
+
+### Backlog reprioritization
+
+- **Elevate #57** to the top of Phase 1; sequence Server Cards (#49/#98/#101) explicitly *after* it (they're inert on STDIO-only).
+- **Fold "cross-model confidence" into #40 Calibrate** as its lead implementation (semantic answer-clustering); don't file it separately. Build the disagreement signal once — #120 and #40 both consume it.
+- **Re-scope #10 Router + #20 Fallback as one "consensus-aware cascade"** that escalates *only on measured disagreement* into the council (Self-MoA: strongest duck synthesizes) — sequence strictly after #40.
+- **Defer #55** listChanged (weak client uptake); **gate #35 Deliberate / #12 Autopilot** behind the disagreement signal — 2025–26 evidence shows multi-agent debate/MoA don't reliably beat self-consistency, so avoid shipping more unconditional debate rounds.
 
 ## Recommended Feature Priority
 
@@ -24,9 +43,11 @@
 
 | # | Feature | Issue | Impact | Effort |
 |---|---------|-------|--------|--------|
-| 5 | Duck Deliberate - Tree-of-Thoughts | [#35](https://github.com/nesquikm/mcp-rubber-duck/issues/35) | High | High |
+| ★ | duck_judge Panel - debiased multi-provider judging | [#119](https://github.com/nesquikm/mcp-rubber-duck/issues/119) | High | Medium |
+| ★ | duck_check - cross-vendor GO/BLOCK action gate | [#120](https://github.com/nesquikm/mcp-rubber-duck/issues/120) | High | Medium |
 | 6 | Duck Hypothesis - Scientific debugging | [#45](https://github.com/nesquikm/mcp-rubber-duck/issues/45) | High | Medium |
-| 7 | Duck Calibrate - Uncertainty quantification | [#40](https://github.com/nesquikm/mcp-rubber-duck/issues/40) | Medium | Low |
+| 7 | Duck Calibrate - Uncertainty quantification (absorbs cross-model confidence) | [#40](https://github.com/nesquikm/mcp-rubber-duck/issues/40) | Medium | Low |
+| 8 | Duck Deliberate - Tree-of-Thoughts (gate behind disagreement signal) | [#35](https://github.com/nesquikm/mcp-rubber-duck/issues/35) | Medium | High |
 
 ### Tier 3 - Advanced Orchestration
 
@@ -44,10 +65,10 @@
 
 ## Suggested Phases
 
-- **Phase 1** (Foundation): ~~outputSchema (#53)~~ → ~~Multi-round tool calling (#69)~~ → Streamable HTTP (#57) + Streaming (#47)
-- **Phase 2** (Differentiation): Duck Hypothesis (#45) + Duck Calibrate (#40) + Duck Deliberate (#35)
-- **Phase 3** (Platform): Resources (#48) + Smart Router (#10) + Fallback Chains (#20)
-- **Phase 4** (Agentic): Duck Autopilot (#12)
+- **Phase 1** (Foundation): ~~outputSchema (#53)~~ → ~~Multi-round tool calling (#69)~~ → **Streamable HTTP (#57)** + Streaming (#47), plus debiased duck_judge Panel (#119) as a near-term hardening
+- **Phase 2** (Differentiation): duck_check action gate (#120) + Duck Calibrate (#40, builds the shared disagreement signal) + Duck Hypothesis (#45)
+- **Phase 3** (Platform): Server Cards (#49/#98/#101, after #57) + Resources (#48) + consensus-aware cascade (#10 + #20, after #40)
+- **Phase 4** (Agentic): Duck Autopilot (#12) + Duck Deliberate (#35), both gated behind the disagreement signal
 
 ## What We Already Have
 
@@ -80,3 +101,8 @@
 - [Multi-Agent Collaboration Survey](https://arxiv.org/abs/2501.06322)
 - [Tree of Thoughts](https://arxiv.org/abs/2305.10601) - 74% vs 4% success on hard problems
 - [KVCOMM](https://arxiv.org/abs/2510.12872) - KV-cache sharing, 70%+ reuse rate
+- [MCP 2026-07-28 Release Candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) - stateless core; Sampling/Roots/Logging deprecated ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577))
+- [Judging LLM-as-a-Judge (MT-Bench)](https://arxiv.org/abs/2306.05685) - position/verbosity/self-enhancement bias in LLM judges (backs #119)
+- [LLMs are not Fair Evaluators](https://arxiv.org/abs/2305.17926) - Balanced Position Calibration / swap-and-average (backs #119)
+- [Multi-Agent Verification](https://arxiv.org/abs/2502.20379) - aspect verifiers / BoN-MAV (backs #120)
+- [Rethinking Mixture-of-Agents (Self-MoA)](https://arxiv.org/abs/2502.00674) - one strong model often beats mixed MoA

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.nesquikm/rubber-duck",
-  "description": "Bridge to multiple LLMs and CLI agents: councils, debates, voting, and more",
+  "description": "Bridge to multiple LLMs and CLI agents: councils, debates, voting, and judging",
   "repository": {
     "url": "https://github.com/nesquikm/mcp-rubber-duck",
     "source": "github"


### PR DESCRIPTION
## What

Documents the outcome of a multi-agent "what's next" research pass and adds spec-alignment positioning copy.

### Changes
- **`docs/roadmap.md`** — new **"Next Up (June 2026 research)"** section with the top picks (debiased `duck_judge` panel #119, Streamable HTTP transport #57, `duck_check` action gate #120), a backlog-reprioritization list, Tier-2 / Phase updates, and new research references.
- **`README.md`** — a "Why direct provider integration?" callout + a **Spec-Aligned by Design** Features bullet.
- **`server.json`** — registry card description now mentions **judging** (kept ≤100 chars per the registry schema's `maxLength`, capability-focused per its guidance).

## Why

The MCP **2026-07-28 release candidate** (SEP-2577, merged 2026-05-15) deprecates server-side **Sampling** — the primitive that let a server borrow the *host's* model — and points servers needing model access toward **integrating directly with LLM provider APIs**. That is exactly how Rubber Duck already works (it brings its own ducks), so the project is aligned with where the protocol is heading, with no code change required.

Framing is deliberately **"aligned with the spec's direction,"** not "official replacement": the deprecation is annotation-only with a 12-month window, and reviewers noted Sampling may return in a more flexible form.

## Related
- Companion issues filed from the same research: #119 (duck_judge panel), #120 (duck_check action gate)
- Strategic lever surfaced: #57 (HTTP transport), which unblocks Server Cards #49/#98/#101

## Notes
- Docs/copy only — no source or test changes (no tests reference `README.md` or `server.json`).
- Pre-existing housekeeping (out of scope): `server.json` `version` (1.18.0) trails `package.json` (1.19.6) — sync on next release.
