### PR TITLE
fix(ci): activate semantic-release releaseRules and prune stale audit allowlist

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,46 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {
+            "breaking": true,
+            "release": "major"
+          },
+          {
+            "revert": true,
+            "release": "patch"
+          },
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "scope": "{deps,deps-dev}",
+            "release": "patch"
+          },
+          {
+            "scope": "no-release",
+            "release": false
+          }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",
@@ -29,47 +68,5 @@
       }
     ],
     "@semantic-release/github"
-  ],
-  "releaseRules": [
-    {
-      "type": "feat",
-      "release": "minor"
-    },
-    {
-      "type": "fix",
-      "release": "patch"
-    },
-    {
-      "type": "docs",
-      "release": false
-    },
-    {
-      "type": "style",
-      "release": false
-    },
-    {
-      "type": "refactor",
-      "release": "patch"
-    },
-    {
-      "type": "perf",
-      "release": "patch"
-    },
-    {
-      "type": "test",
-      "release": false
-    },
-    {
-      "scope": "deps",
-      "release": "patch"
-    },
-    {
-      "type": "chore",
-      "release": false
-    },
-    {
-      "scope": "no-release",
-      "release": false
-    }
   ]
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -4,9 +4,5 @@
   "high": true,
   "critical": true,
   "report-type": "summary",
-  "allowlist": [
-    "GHSA-3v7f-55p6-f55p",
-    "GHSA-c2c7-rcm5-vvqj",
-    "GHSA-f886-m6hf-6m8v"
-  ]
+  "allowlist": []
 }


### PR DESCRIPTION
## What

Two fixes uncovered while shipping the esbuild security bump (1.19.8):

### 1. `.releaserc.json` — `releaseRules` was dead config
The `releaseRules` array sat at the **top level**, where semantic-release ignores it (it's only honored inside the `@semantic-release/commit-analyzer` plugin). So the default Angular preset applied and dependabot `chore(deps)` bumps never auto-released — which is why 1.19.8 had to be hand-typed as `fix:`.

Moved the rules into the plugin and corrected two latent traps found in the process:
- **Re-added `{breaking → major}` / `{revert → patch}`.** Custom `releaseRules` short-circuit the defaults, so without these a breaking `feat!`/`fix!` would silently downgrade to minor/patch.
- **Dropped redundant `{docs,style,test,chore → false}` rules.** semantic-release's comparator ranks `false` (`indexOf -1`) above every real release type, so a matching `false` rule clobbers a real one — this made `chore(deps)` resolve to *no release*. The default fallback already yields no-release for those types.
- **Broadened scope `deps` → `{deps,deps-dev}`** so prod + dev dependabot bumps both auto-release as patch. Kept the `no-release` escape hatch (last, where it correctly overrides).

### 2. `audit-ci.json` — pruned stale allowlist
Removed `GHSA-3v7f-55p6-f55p`, `GHSA-c2c7-rcm5-vvqj`, `GHSA-f886-m6hf-6m8v` (audit-ci flagged them as no longer encountered).

## Verification
- Offline test against the **real** `@semantic-release/commit-analyzer` module: **17/17** cases (incl. `chore(deps)`/`chore(deps-dev)` → patch, breaking → major, `no-release` override).
- Full gate: build ✅, typecheck ✅, lint ✅, **1114 tests** ✅, audit-ci ✅ (warning gone).

> Note: with this change, future dependabot bumps auto-release as patch.