### PR TITLE
fix: remediate 5 HIGH-severity code-review findings (M2)

### DIFF
--- a/docs/mcp-bridge.md
+++ b/docs/mcp-bridge.md
@@ -32,8 +32,9 @@ MCP_TRUSTED_TOOLS_CONTEXT7="*"
 ## Approval Modes
 
 **`always`**: Every tool call requires approval (with session-based memory)
-- First use of a tool -> requires approval
-- Subsequent uses of the same tool -> automatic (until restart)
+- First use of a tool (with specific arguments) -> requires approval
+- Subsequent *identical* calls (same provider + server + tool + arguments) -> automatic, until the approval TTL expires
+- A material change in arguments, or TTL expiry -> re-prompts
 
 **`trusted`**: Only untrusted tools require approval
 - Tools in trusted lists execute immediately
@@ -120,11 +121,27 @@ Result: 500 tokens instead of 5,000+ tokens of raw documentation
 
 ## Session-Based Approvals
 
-When using `always` mode, the system remembers your approvals:
+When using `always` mode, the system remembers your approvals — but scoped
+narrowly so a one-time approval can never be replayed against a different action.
 
-1. **First time**: "Duck wants to use `search-docs` - Approve?"
-2. **Next time**: Duck uses `search-docs` automatically (no new approval needed)
-3. **Different tool**: "Duck wants to use `get-examples` - Approve?"
-4. **Restart**: Session memory clears, start over
+A session approval is keyed by **provider name + server + tool + a hash of the
+normalized arguments**, and each approval carries a **TTL** equal to
+`MCP_APPROVAL_TIMEOUT` (default 300s). It auto-approves only an *identical* later
+call, and only until it expires:
 
-This eliminates approval fatigue while maintaining security!
+1. **First time**: "Duck wants to use `search-docs` (with these arguments) - Approve?"
+2. **Next time (same tool + same arguments)**: runs automatically — until the TTL expires
+3. **Same tool, different arguments**: re-prompts (a new approval is required)
+4. **After the TTL elapses**: re-prompts
+5. **Different tool / different server**: re-prompts
+6. **Different provider that happens to share a nickname**: does **not** inherit the approval — the principal is the stable provider *name*, not the display nickname
+7. **Restart**: session memory clears, start over
+
+This eliminates approval fatigue for genuinely repeated actions while ensuring a
+single approval can never authorize a different tool, different arguments, or a
+different provider.
+
+> **Single-use approval IDs.** When a duck retries a call with a pre-issued
+> `_approval_id`, that ID is bound to its originating call (provider + server +
+> tool + arguments) and is consumed after one successful execution — it cannot be
+> replayed for a different tool, different arguments, or used twice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-rubber-duck",
-  "version": "1.19.7",
+  "version": "1.19.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-rubber-duck",
-      "version": "1.19.7",
+      "version": "1.19.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.1",
@@ -76,12 +76,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -100,21 +100,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -141,14 +141,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -158,14 +158,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -195,29 +195,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -247,18 +247,18 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -266,27 +266,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -535,33 +535,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -569,14 +569,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4021,9 +4021,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4093,9 +4093,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -4113,11 +4113,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4214,9 +4214,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -4908,9 +4908,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.373",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+      "integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5802,16 +5802,16 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5822,6 +5822,18 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
@@ -7310,9 +7322,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8248,11 +8270,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "8.0.0",
@@ -8291,9 +8316,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.16.0.tgz",
-      "integrity": "sha512-A74XL8OxmcegZDMWPkWb5bEQppg8HdYwW3rBD2sPoS4UQHVajfaxBkqyzLeJ3wR0kZ+5xoTjItxXaF7eIXUsyw==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -8371,8 +8396,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.7.0",
-        "@npmcli/config": "^10.10.0",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -8396,11 +8421,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.9",
-        "libnpmexec": "^10.2.9",
-        "libnpmfund": "^7.0.23",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.9",
+        "libnpmpack": "^9.1.10",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -8410,7 +8435,7 @@
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -8420,16 +8445,16 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.1",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.15",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -8497,7 +8522,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.7.0",
+      "version": "9.8.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8544,7 +8569,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.10.0",
+      "version": "10.11.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9201,11 +9226,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.9",
+      "version": "8.1.10",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -9219,12 +9244,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.9",
+      "version": "10.3.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -9241,11 +9266,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.23",
+      "version": "7.0.24",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.7.0"
+        "@npmcli/arborist": "^9.8.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -9264,11 +9289,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.9",
+      "version": "9.1.10",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -9494,7 +9519,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.3.0",
+      "version": "12.4.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9658,7 +9683,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9716,7 +9741,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9803,7 +9828,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -9917,7 +9942,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.15",
+      "version": "7.5.16",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9942,7 +9967,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11570,9 +11595,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12378,19 +12403,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -12407,7 +12432,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -225,13 +225,23 @@ export class ConfigManager {
       if (maxRounds !== undefined) mcpConfig.max_tool_rounds = maxRounds;
     }
 
-    // Parse per-server trusted tools from environment
-    mcpConfig.trusted_tools_by_server = this.getTrustedToolsByServerFromEnv();
+    // Parse per-server trusted tools from environment.
+    // Only overwrite file-defined values when the env-derived list is non-empty,
+    // so file-provided values (carried via {...existingConfig}) are preserved.
+    const trustedToolsByServerFromEnv = this.getTrustedToolsByServerFromEnv();
+    if (Object.keys(trustedToolsByServerFromEnv).length > 0) {
+      mcpConfig.trusted_tools_by_server = trustedToolsByServerFromEnv;
+    }
 
-    // Configure MCP servers from environment
-    mcpConfig.mcp_servers = this.getMCPServersFromEnv();
+    // Configure MCP servers from environment (same non-empty guard).
+    const mcpServersFromEnv = this.getMCPServersFromEnv();
+    if (mcpServersFromEnv.length > 0) {
+      mcpConfig.mcp_servers = mcpServersFromEnv;
+    }
 
-    return mcpConfig.enabled || mcpConfig.mcp_servers?.length > 0 ? mcpConfig : existingConfig;
+    return mcpConfig.enabled || (mcpConfig.mcp_servers?.length ?? 0) > 0
+      ? mcpConfig
+      : existingConfig;
   }
 
   private hasMCPServerConfig(): boolean {

--- a/src/providers/duck-provider-enhanced.ts
+++ b/src/providers/duck-provider-enhanced.ts
@@ -231,7 +231,7 @@ export class EnhancedDuckProvider extends DuckProvider {
           SafeLogger.debug(`Function call arguments for ${functionName}:`, args);
 
           const result = await this.functionBridge.handleFunctionCall(
-            this.nickname,
+            this.name,
             functionName,
             args
           );

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,8 @@ import { GuardrailsService } from './guardrails/service.js';
 import { TaskManager } from './services/task-manager.js';
 import { createProgressReporter } from './services/progress.js';
 import { logger } from './utils/logger.js';
-import { duckArt, getRandomDuckMessage } from './utils/ascii-art.js';
+import { getRandomDuckMessage } from './utils/ascii-art.js';
+import { printWelcomeBanner } from './utils/banner.js';
 
 // Import tools
 import { askDuckTool } from './tools/ask-duck.js';
@@ -1206,14 +1207,9 @@ export class RubberDuckServer {
   }
 
   async start() {
-    // Only show welcome message when not running as MCP server
-    const isMCP = process.env.MCP_SERVER === 'true' || process.argv.includes('--mcp');
-    if (!isMCP) {
-      // eslint-disable-next-line no-console
-      console.log(duckArt.welcome);
-      // eslint-disable-next-line no-console
-      console.log('\n' + getRandomDuckMessage('startup'));
-    }
+    // The welcome banner always goes to stderr (see printWelcomeBanner), so it is
+    // safe to print in every mode — stdout stays reserved for framed JSON-RPC.
+    printWelcomeBanner();
 
     // Initialize guardrails service if configured
     if (this.guardrailsService) {

--- a/src/services/approval.ts
+++ b/src/services/approval.ts
@@ -1,6 +1,7 @@
 import { logger } from '../utils/logger.js';
 import { SafeLogger } from '../utils/safe-logger.js';
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
+import { canonicalJSONStringify } from '../utils/canonical-json.js';
 
 export interface ApprovalRequest {
   id: string;
@@ -9,19 +10,21 @@ export interface ApprovalRequest {
   mcpServer: string;
   toolName: string;
   arguments: Record<string, unknown>;
-  status: 'pending' | 'approved' | 'denied' | 'expired';
+  status: 'pending' | 'approved' | 'denied' | 'expired' | 'consumed';
   approvedBy?: string;
   deniedReason?: string;
   expiresAt: number;
 }
 
-export type ApprovalStatus = 'pending' | 'approved' | 'denied' | 'expired';
+export type ApprovalStatus = 'pending' | 'approved' | 'denied' | 'expired' | 'consumed';
 
 export class ApprovalService {
   private pendingApprovals: Map<string, ApprovalRequest> = new Map();
   private approvalTimeout: number;
   private cleanupInterval: NodeJS.Timeout | null = null;
-  private approvedToolsForSession: Set<string> = new Set();
+  // Maps a session approval key -> expiresAt (epoch ms). The key is scoped by
+  // principal (provider name) + server + tool + normalized-args-hash.
+  private approvedToolsForSession: Map<string, number> = new Map();
 
   constructor(approvalTimeoutSeconds: number = 300) {
     this.approvalTimeout = approvalTimeoutSeconds * 1000; // Convert to milliseconds
@@ -102,13 +105,43 @@ export class ApprovalService {
     request.status = 'approved';
     request.approvedBy = approvedBy;
 
-    // Mark tool as approved for this session
-    const sessionKey = this.createSessionKey(request.duckName, request.mcpServer, request.toolName);
-    this.approvedToolsForSession.add(sessionKey);
+    // Mark tool as approved for this session, scoped by principal + server +
+    // tool + args-hash and carrying a TTL derived from the approval timeout.
+    const sessionKey = this.createSessionKey(
+      request.duckName,
+      request.mcpServer,
+      request.toolName,
+      request.arguments
+    );
+    this.approvedToolsForSession.set(sessionKey, Date.now() + this.approvalTimeout);
 
     logger.info(
       `Approval request ${id} approved by ${approvedBy} - tool ${sessionKey} now approved for session`
     );
+    return true;
+  }
+
+  /**
+   * Consume an approved request, transitioning it to the terminal `consumed`
+   * status. Single-use: returns true only on a valid approved→consumed
+   * transition; returns false if the request is missing or not in the
+   * `approved` state (e.g. already consumed).
+   */
+  consumeApproval(id: string): boolean {
+    const request = this.getApprovalRequest(id);
+
+    if (!request) {
+      logger.warn(`Approval request ${id} not found`);
+      return false;
+    }
+
+    if (request.status !== 'approved') {
+      logger.warn(`Approval request ${id} is not approved (status: ${request.status})`);
+      return false;
+    }
+
+    request.status = 'consumed';
+    logger.info(`Approval request ${id} consumed (single-use)`);
     return true;
   }
 
@@ -187,18 +220,54 @@ export class ApprovalService {
   }
 
   // Session-based approval methods
-  private createSessionKey(duckName: string, mcpServer: string, toolName: string): string {
-    return `${duckName}:${mcpServer}:${toolName}`;
+  //
+  // The session key is scoped by the principal (provider name), the MCP server,
+  // the tool name, and a hash of the normalized (canonical, key-sorted) args.
+  // This ensures: (1) two providers sharing a human nickname cannot
+  // cross-authorize (the principal is the stable provider name), and (2) an
+  // approval for one set of arguments does not auto-approve a materially
+  // different set.
+  private createSessionKey(
+    principal: string,
+    mcpServer: string,
+    toolName: string,
+    args: Record<string, unknown>
+  ): string {
+    const argsHash = createHash('sha256').update(canonicalJSONStringify(args)).digest('hex');
+    return `${principal}:${mcpServer}:${toolName}:${argsHash}`;
   }
 
-  isToolApprovedForSession(duckName: string, mcpServer: string, toolName: string): boolean {
-    const sessionKey = this.createSessionKey(duckName, mcpServer, toolName);
-    return this.approvedToolsForSession.has(sessionKey);
+  isToolApprovedForSession(
+    principal: string,
+    mcpServer: string,
+    toolName: string,
+    args: Record<string, unknown>
+  ): boolean {
+    const sessionKey = this.createSessionKey(principal, mcpServer, toolName, args);
+    const expiresAt = this.approvedToolsForSession.get(sessionKey);
+
+    if (expiresAt === undefined) {
+      return false;
+    }
+
+    // Expired approvals are evicted and treated as not approved, forcing a
+    // fresh approval prompt.
+    if (Date.now() >= expiresAt) {
+      this.approvedToolsForSession.delete(sessionKey);
+      return false;
+    }
+
+    return true;
   }
 
-  markToolAsApprovedForSession(duckName: string, mcpServer: string, toolName: string): void {
-    const sessionKey = this.createSessionKey(duckName, mcpServer, toolName);
-    this.approvedToolsForSession.add(sessionKey);
+  markToolAsApprovedForSession(
+    principal: string,
+    mcpServer: string,
+    toolName: string,
+    args: Record<string, unknown>
+  ): void {
+    const sessionKey = this.createSessionKey(principal, mcpServer, toolName, args);
+    this.approvedToolsForSession.set(sessionKey, Date.now() + this.approvalTimeout);
     logger.info(`Tool ${sessionKey} marked as approved for session`);
   }
 
@@ -209,7 +278,7 @@ export class ApprovalService {
   }
 
   getSessionApprovals(): string[] {
-    return Array.from(this.approvedToolsForSession);
+    return Array.from(this.approvedToolsForSession.keys());
   }
 
   // For debugging/admin purposes
@@ -219,6 +288,7 @@ export class ApprovalService {
     approved: number;
     denied: number;
     expired: number;
+    consumed: number;
   } {
     this.cleanupExpired();
 
@@ -230,6 +300,7 @@ export class ApprovalService {
       approved: all.filter((r) => r.status === 'approved').length,
       denied: all.filter((r) => r.status === 'denied').length,
       expired: all.filter((r) => r.status === 'expired').length,
+      consumed: all.filter((r) => r.status === 'consumed').length,
     };
   }
 }

--- a/src/services/function-bridge.ts
+++ b/src/services/function-bridge.ts
@@ -5,6 +5,7 @@ import Ajv, { ValidateFunction } from 'ajv';
 import { GuardrailsService } from '../guardrails/service.js';
 import { GuardrailContext } from '../guardrails/types.js';
 import { GuardrailBlockError } from '../guardrails/errors.js';
+import { canonicalJSONStringify } from '../utils/canonical-json.js';
 
 export interface FunctionDefinition {
   name: string;
@@ -206,7 +207,8 @@ export class FunctionBridge {
       const isAlreadyApprovedForSession = this.approvalService.isToolApprovedForSession(
         duckName,
         mcpServer,
-        mcpTool
+        mcpTool,
+        cleanArgs
       );
       let needsApproval = false;
 
@@ -245,14 +247,25 @@ export class FunctionBridge {
         };
       }
 
-      // If approval ID provided, verify it (except in 'never' mode)
+      // If approval ID provided, verify it (except in 'never' mode).
+      // Bind the approval to this exact call: the referenced request must be
+      // approved AND match the duck/server/tool AND have args that deep-equal
+      // the approved args (canonical, key-sorted JSON). This prevents replaying
+      // an approval ID against a different server/tool or with different args.
       if (approvalId && this.approvalMode !== 'never') {
-        const approvalStatus = this.approvalService.getApprovalStatus(approvalId);
+        const request = this.approvalService.getApprovalRequest(approvalId);
 
-        if (approvalStatus !== 'approved') {
+        if (
+          !request ||
+          request.status !== 'approved' ||
+          request.duckName !== duckName ||
+          request.mcpServer !== mcpServer ||
+          request.toolName !== mcpTool ||
+          canonicalJSONStringify(cleanArgs) !== canonicalJSONStringify(request.arguments)
+        ) {
           return {
             success: false,
-            error: `Request not approved or expired (status: ${approvalStatus})`,
+            error: `Request not approved or expired (status: ${request?.status ?? 'not found'})`,
           };
         }
       }
@@ -282,6 +295,12 @@ export class FunctionBridge {
       // Execute the MCP tool
       logger.info(`Executing MCP tool ${mcpServer}:${mcpTool} for ${duckName}`);
       const result = await this.mcpManager.callTool(mcpServer, mcpTool, cleanArgs);
+
+      // Consume the approval ID after a successful execution (single-use): a
+      // replay of the same ID will then be rejected by the binding check above.
+      if (approvalId && this.approvalMode !== 'never') {
+        this.approvalService.consumeApproval(approvalId);
+      }
 
       // Execute post_tool_output guardrails
       if (guardrailContext && this.guardrailsService?.isEnabled()) {

--- a/src/tools/duck-iterate.ts
+++ b/src/tools/duck-iterate.ts
@@ -57,6 +57,7 @@ export async function duckIterateTool(
 
   const rounds: IterationRound[] = [];
   let lastResponse = '';
+  let lastImprovement = '';
   let converged = false;
 
   if (signal?.aborted) {
@@ -77,6 +78,7 @@ export async function duckIterateTool(
   });
 
   lastResponse = initialResponse.content;
+  lastImprovement = initialResponse.content;
   logger.info(`Round 1: ${providers[0]} generated initial response`);
 
   if (progress) {
@@ -115,6 +117,9 @@ export async function duckIterateTool(
     });
 
     lastResponse = response.content;
+    if (role !== 'critic') {
+      lastImprovement = response.content;
+    }
     logger.info(`Round ${i}: ${currentProvider} ${role === 'critic' ? 'critiqued' : 'refined'}`);
 
     if (progress) {
@@ -131,7 +136,7 @@ export async function duckIterateTool(
     mode,
     providers,
     rounds,
-    finalResponse: lastResponse,
+    finalResponse: lastImprovement,
     totalIterations: rounds.length,
     converged,
   };

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -1,0 +1,12 @@
+import { duckArt, getRandomDuckMessage } from './ascii-art.js';
+
+/**
+ * Print the welcome banner to STDERR.
+ *
+ * The server always communicates over stdio, where stdout carries framed
+ * JSON-RPC. Writing the banner to stderr keeps stdout clean in every mode.
+ */
+export function printWelcomeBanner(): void {
+  console.error(duckArt.welcome);
+  console.error('\n' + getRandomDuckMessage('startup'));
+}

--- a/src/utils/canonical-json.ts
+++ b/src/utils/canonical-json.ts
@@ -1,0 +1,26 @@
+/**
+ * Produce a canonical (deterministic) JSON string for a value by recursively
+ * sorting object keys. Arrays preserve their order; only object key order is
+ * normalized. Useful for stable deep-equality comparison and hashing of
+ * structurally-equal values regardless of key insertion order.
+ */
+export function canonicalJSONStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+
+  const obj = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    sorted[key] = canonicalize(obj[key]);
+  }
+  return sorted;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -70,9 +70,13 @@ export const logger = winston.createLogger({
     winston.format.json()
   ),
   transports: [
-    new winston.transports.Console({
+    // The server always talks over stdio, so stdout carries framed JSON-RPC.
+    // Write every log level straight to process.stderr so no log line ever
+    // lands on stdout (winston's Console transport can route through
+    // console._stdout, which is unsafe under stdio).
+    new winston.transports.Stream({
+      stream: process.stderr,
       format: consoleFormat,
-      silent: isMCP, // Always silence console logs in MCP mode to avoid interfering with JSON-RPC
     }),
   ],
 });

--- a/tests/approval.test.ts
+++ b/tests/approval.test.ts
@@ -178,7 +178,7 @@ describe('ApprovalService', () => {
 
       service.approveRequest(request.id);
 
-      expect(service.isToolApprovedForSession('TestDuck', 'filesystem', 'read_file')).toBe(true);
+      expect(service.isToolApprovedForSession('TestDuck', 'filesystem', 'read_file', {})).toBe(true);
     });
   });
 
@@ -320,41 +320,79 @@ describe('ApprovalService', () => {
 
   describe('session approvals', () => {
     it('should track tool approvals for session', () => {
-      expect(service.isToolApprovedForSession('Duck', 'server', 'tool')).toBe(false);
+      expect(service.isToolApprovedForSession('Duck', 'server', 'tool', {})).toBe(false);
 
-      service.markToolAsApprovedForSession('Duck', 'server', 'tool');
+      service.markToolAsApprovedForSession('Duck', 'server', 'tool', {});
 
-      expect(service.isToolApprovedForSession('Duck', 'server', 'tool')).toBe(true);
+      expect(service.isToolApprovedForSession('Duck', 'server', 'tool', {})).toBe(true);
     });
 
     it('should differentiate between duck/server/tool combinations', () => {
-      service.markToolAsApprovedForSession('Duck1', 'server', 'tool');
+      service.markToolAsApprovedForSession('Duck1', 'server', 'tool', {});
 
-      expect(service.isToolApprovedForSession('Duck1', 'server', 'tool')).toBe(true);
-      expect(service.isToolApprovedForSession('Duck2', 'server', 'tool')).toBe(false);
-      expect(service.isToolApprovedForSession('Duck1', 'other', 'tool')).toBe(false);
-      expect(service.isToolApprovedForSession('Duck1', 'server', 'other')).toBe(false);
+      expect(service.isToolApprovedForSession('Duck1', 'server', 'tool', {})).toBe(true);
+      expect(service.isToolApprovedForSession('Duck2', 'server', 'tool', {})).toBe(false);
+      expect(service.isToolApprovedForSession('Duck1', 'other', 'tool', {})).toBe(false);
+      expect(service.isToolApprovedForSession('Duck1', 'server', 'other', {})).toBe(false);
     });
 
     it('should clear session approvals', () => {
-      service.markToolAsApprovedForSession('Duck1', 'server', 'tool1');
-      service.markToolAsApprovedForSession('Duck2', 'server', 'tool2');
+      service.markToolAsApprovedForSession('Duck1', 'server', 'tool1', {});
+      service.markToolAsApprovedForSession('Duck2', 'server', 'tool2', {});
 
       service.clearSessionApprovals();
 
-      expect(service.isToolApprovedForSession('Duck1', 'server', 'tool1')).toBe(false);
-      expect(service.isToolApprovedForSession('Duck2', 'server', 'tool2')).toBe(false);
+      expect(service.isToolApprovedForSession('Duck1', 'server', 'tool1', {})).toBe(false);
+      expect(service.isToolApprovedForSession('Duck2', 'server', 'tool2', {})).toBe(false);
     });
 
     it('should get all session approvals', () => {
-      service.markToolAsApprovedForSession('Duck1', 'server', 'tool1');
-      service.markToolAsApprovedForSession('Duck2', 'server', 'tool2');
+      service.markToolAsApprovedForSession('Duck1', 'server', 'tool1', {});
+      service.markToolAsApprovedForSession('Duck2', 'server', 'tool2', {});
 
       const approvals = service.getSessionApprovals();
 
+      // Keys now embed an args hash + the provider-name principal, so do not assert
+      // the legacy `Duck:server:tool` string — assert membership by recompute instead.
       expect(approvals).toHaveLength(2);
-      expect(approvals).toContain('Duck1:server:tool1');
-      expect(approvals).toContain('Duck2:server:tool2');
+      expect(service.isToolApprovedForSession('Duck1', 'server', 'tool1', {})).toBe(true);
+      expect(service.isToolApprovedForSession('Duck2', 'server', 'tool2', {})).toBe(true);
+    });
+
+    // AC-R5S9MH.2 — args-hash keying: a session approval for argsX must NOT
+    // auto-approve the same principal/server/tool with materially different argsY.
+    it('should not approve when args differ from the approved args', () => {
+      const argsX = { path: '/safe.txt' };
+      const argsY = { path: '/etc/shadow' };
+
+      service.markToolAsApprovedForSession('openai', 'filesystem', 'read_file', argsX);
+
+      expect(service.isToolApprovedForSession('openai', 'filesystem', 'read_file', argsX)).toBe(true);
+      expect(service.isToolApprovedForSession('openai', 'filesystem', 'read_file', argsY)).toBe(false);
+    });
+
+    // AC-R5S9MH.2 — TTL expiry: a session approval expires after approval_timeout.
+    it('should expire a session approval after the approval timeout (TTL)', () => {
+      const args = { path: '/safe.txt' };
+      service.markToolAsApprovedForSession('openai', 'filesystem', 'read_file', args);
+
+      expect(service.isToolApprovedForSession('openai', 'filesystem', 'read_file', args)).toBe(true);
+
+      // Advance beyond the 60s approval_timeout configured in beforeEach.
+      jest.advanceTimersByTime(61000);
+
+      expect(service.isToolApprovedForSession('openai', 'filesystem', 'read_file', args)).toBe(false);
+    });
+
+    // AC-R5S9MH.2 — principal scoping: the principal is the provider NAME, not the
+    // nickname. Marking for provider 'openai' must not authorize provider 'google'
+    // even when both share the same server/tool/args.
+    it('should scope approvals to the provider-name principal', () => {
+      const args = { path: '/safe.txt' };
+      service.markToolAsApprovedForSession('openai', 'filesystem', 'read_file', args);
+
+      expect(service.isToolApprovedForSession('openai', 'filesystem', 'read_file', args)).toBe(true);
+      expect(service.isToolApprovedForSession('google', 'filesystem', 'read_file', args)).toBe(false);
     });
   });
 

--- a/tests/canonical-json.test.ts
+++ b/tests/canonical-json.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from '@jest/globals';
+import { canonicalJSONStringify } from '../src/utils/canonical-json';
+
+/**
+ * canonicalJSONStringify underpins two security-critical behaviors:
+ *  - AC-R5S9MH.1: deep-equality of cleaned args against the approved args
+ *    (an approval ID must not be replayable with different args).
+ *  - AC-R5S9MH.2: the normalized-args-hash component of a session-approval key.
+ *
+ * The load-bearing property is key-order independence: structurally-equal
+ * objects must canonicalize to the same string regardless of key insertion
+ * order, while any value difference must produce a different string.
+ */
+describe('canonicalJSONStringify', () => {
+  it('produces identical output for objects differing only in key order', () => {
+    expect(canonicalJSONStringify({ a: 1, b: 2 })).toBe(canonicalJSONStringify({ b: 2, a: 1 }));
+  });
+
+  it('sorts nested object keys recursively', () => {
+    const a = { outer: { z: 1, a: 2 }, list: [{ y: 1, x: 2 }] };
+    const b = { list: [{ x: 2, y: 1 }], outer: { a: 2, z: 1 } };
+    expect(canonicalJSONStringify(a)).toBe(canonicalJSONStringify(b));
+    // And the canonical string actually has keys in sorted order.
+    expect(canonicalJSONStringify({ z: 1, a: 2 })).toBe('{"a":2,"z":1}');
+  });
+
+  it('preserves array element order (arrays are sequences, not sets)', () => {
+    expect(canonicalJSONStringify([1, 2, 3])).toBe('[1,2,3]');
+    expect(canonicalJSONStringify([3, 2, 1])).not.toBe(canonicalJSONStringify([1, 2, 3]));
+  });
+
+  it('distinguishes different values', () => {
+    expect(canonicalJSONStringify({ path: '/a.txt' })).not.toBe(
+      canonicalJSONStringify({ path: '/etc/shadow' })
+    );
+  });
+
+  it('distinguishes a present-valued key from an absent one', () => {
+    expect(canonicalJSONStringify({ a: 1, b: 2 })).not.toBe(canonicalJSONStringify({ a: 1 }));
+  });
+
+  it('treats an explicitly-undefined value as absent (JSON.stringify semantics)', () => {
+    // An arg passed as `undefined` is equivalent to not passing it — both must
+    // hash/compare identically so approval binding is not fooled either way.
+    expect(canonicalJSONStringify({ a: 1, b: undefined })).toBe(canonicalJSONStringify({ a: 1 }));
+  });
+
+  it('round-trips primitives and null', () => {
+    expect(canonicalJSONStringify('s')).toBe('"s"');
+    expect(canonicalJSONStringify(42)).toBe('42');
+    expect(canonicalJSONStringify(true)).toBe('true');
+    expect(canonicalJSONStringify(null)).toBe('null');
+  });
+
+  it('handles empty containers', () => {
+    expect(canonicalJSONStringify({})).toBe('{}');
+    expect(canonicalJSONStringify([])).toBe('[]');
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { ConfigManager } from '../src/config/config';
 import type { HttpProviderConfig, ProviderConfig } from '../src/config/types';
 
@@ -893,5 +896,92 @@ describe('ConfigManager - CLI Providers', () => {
 
     // Provider should have type 'http' after parsing
     expect(providers.openai.type).toBe('http');
+  });
+});
+
+/**
+ * AC-R5S9MH.4 (H4) — config file-vs-env merge for the MCP bridge.
+ *
+ * When config.json defines mcp_servers (and/or trusted_tools_by_server) and NO
+ * MCP_SERVER_* / MCP_TRUSTED_TOOLS_* env vars are set, getMCPBridgeConfig must
+ * PRESERVE the file values. Env-derived lists overwrite only when non-empty.
+ */
+describe('ConfigManager - MCP Bridge file-vs-env merge (AC-R5S9MH.4)', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    jest.clearAllMocks();
+
+    // Clear all MCP-related and provider env vars so nothing leaks into the merge
+    Object.keys(process.env).forEach((key) => {
+      if (key.startsWith('MCP_')) delete process.env[key];
+      if (key.startsWith('CUSTOM_')) delete process.env[key];
+    });
+    delete process.env.OPENAI_API_KEY;
+
+    tmpDir = mkdtempSync(join(tmpdir(), 'rubber-duck-config-'));
+    configPath = join(tmpDir, 'config.json');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('preserves file-defined mcp_servers when no MCP_SERVER_* env vars are set', () => {
+    const fileConfig = {
+      providers: {
+        openai: {
+          api_key: 'sk-file-key',
+          base_url: 'https://api.openai.com/v1',
+          default_model: 'gpt-4',
+          nickname: 'File GPT',
+          models: ['gpt-4'],
+        },
+      },
+      default_provider: 'openai',
+      mcp_bridge: {
+        enabled: true,
+        mcp_servers: [{ name: 'filesystem', type: 'stdio', command: 'echo' }],
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(fileConfig));
+
+    const configManager = new ConfigManager(configPath);
+    const servers = configManager.getConfig().mcp_bridge?.mcp_servers;
+
+    expect(servers).toBeDefined();
+    expect(servers).toHaveLength(1);
+    expect(servers?.[0].name).toBe('filesystem');
+  });
+
+  it('preserves file-defined trusted_tools_by_server when no env vars are set', () => {
+    const fileConfig = {
+      providers: {
+        openai: {
+          api_key: 'sk-file-key',
+          base_url: 'https://api.openai.com/v1',
+          default_model: 'gpt-4',
+          nickname: 'File GPT',
+          models: ['gpt-4'],
+        },
+      },
+      default_provider: 'openai',
+      mcp_bridge: {
+        enabled: true,
+        mcp_servers: [{ name: 'filesystem', type: 'stdio', command: 'echo' }],
+        trusted_tools_by_server: { filesystem: ['read_file'] },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(fileConfig));
+
+    const configManager = new ConfigManager(configPath);
+    const trustedByServer = configManager.getConfig().mcp_bridge?.trusted_tools_by_server;
+
+    expect(trustedByServer).toBeDefined();
+    expect(trustedByServer?.filesystem).toEqual(['read_file']);
   });
 });

--- a/tests/duck-iterate.test.ts
+++ b/tests/duck-iterate.test.ts
@@ -359,4 +359,63 @@ describe('duckIterateTool', () => {
     expect(mockProgress.report).toHaveBeenNthCalledWith(2, 2, 3, expect.stringContaining('Round 2/3'));
     expect(mockProgress.report).toHaveBeenNthCalledWith(3, 3, 3, expect.stringContaining('Round 3/3'));
   });
+
+  // AC-R5S9MH.5 (H5): in critique-improve mode the final response must always be an
+  // improvement/answer, never a critique — including when iterations is even and the
+  // last round is a critic round. We assert against the "Final Response" section only,
+  // since the critique text legitimately appears in the iteration-history section.
+  const FINAL_MARKER = '🏁 **Final Response:**';
+
+  function finalResponseSection(text: string): string {
+    const idx = text.indexOf(FINAL_MARKER);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    return text.slice(idx);
+  }
+
+  function mockRound(content: string, model: string) {
+    return {
+      choices: [{ message: { content }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      model,
+    };
+  }
+
+  it('critique-improve with iterations=2 returns the round-1 improvement, not the round-2 critique', async () => {
+    // Round 1 = generator/improvement, Round 2 = critic.
+    // Distinctive, non-similar contents so convergence does NOT trigger.
+    mockCreate
+      .mockResolvedValueOnce(mockRound('GEN_ROUND_1', 'gpt-4'))
+      .mockResolvedValueOnce(mockRound('CRITIQUE_ROUND_2', 'gemini-pro'));
+
+    const result = await duckIterateTool(mockProviderManager, {
+      prompt: 'Write a function',
+      providers: ['openai', 'google'],
+      mode: 'critique-improve',
+      iterations: 2,
+    });
+
+    const finalSection = finalResponseSection(result.content[0].text);
+    expect(finalSection).toContain('GEN_ROUND_1');
+    expect(finalSection).not.toContain('CRITIQUE_ROUND_2');
+  });
+
+  it('critique-improve with iterations=4 returns the round-3 improvement, not the round-4 critique', async () => {
+    // Round 1 = generator, Round 2 = critic, Round 3 = improvement, Round 4 = critic.
+    mockCreate
+      .mockResolvedValueOnce(mockRound('GEN_ROUND_1', 'gpt-4'))
+      .mockResolvedValueOnce(mockRound('CRITIQUE_ROUND_2', 'gemini-pro'))
+      .mockResolvedValueOnce(mockRound('IMPROVE_ROUND_3', 'gpt-4'))
+      .mockResolvedValueOnce(mockRound('CRITIQUE_ROUND_4', 'gemini-pro'));
+
+    const result = await duckIterateTool(mockProviderManager, {
+      prompt: 'Write a function',
+      providers: ['openai', 'google'],
+      mode: 'critique-improve',
+      iterations: 4,
+    });
+
+    const finalSection = finalResponseSection(result.content[0].text);
+    expect(finalSection).toContain('IMPROVE_ROUND_3');
+    expect(finalSection).not.toContain('CRITIQUE_ROUND_4');
+  });
 });

--- a/tests/function-bridge.test.ts
+++ b/tests/function-bridge.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { ApprovalService } from '../src/services/approval';
+import { FunctionBridge } from '../src/services/function-bridge';
+import { MCPClientManager } from '../src/services/mcp-client-manager';
+
+// Mock loggers to avoid console noise during tests
+jest.mock('../src/utils/logger');
+jest.mock('../src/utils/safe-logger');
+
+/**
+ * AC-R5S9MH.1 (H1) — approval-ID binding + single-use.
+ *
+ * When a duck supplies `_approval_id`, handleFunctionCall must reject the call
+ * unless the referenced ApprovalRequest matches the current call's duckName,
+ * mcpServer, toolName AND the cleaned args deep-equal the approved arguments.
+ * An approval ID becomes single-use: after one successful tool execution it is
+ * consumed and a replay with the same ID is rejected.
+ */
+describe('FunctionBridge approval-ID binding (AC-R5S9MH.1)', () => {
+  let approvalService: ApprovalService;
+  let mcpManager: MCPClientManager;
+  let functionBridge: FunctionBridge;
+
+  beforeEach(() => {
+    approvalService = new ApprovalService(300); // 5 minutes
+    mcpManager = new MCPClientManager([]);
+    // 'always' approval mode: every call needs approval unless a valid _approval_id is supplied
+    functionBridge = new FunctionBridge(mcpManager, approvalService, [], 'always');
+  });
+
+  afterEach(() => {
+    approvalService.shutdown();
+    jest.restoreAllMocks();
+  });
+
+  it('accepts a correctly-matching approval and executes the tool', async () => {
+    const callToolSpy = jest
+      .spyOn(mcpManager, 'callTool')
+      .mockResolvedValue({ ok: true });
+
+    // Approve for (duckA, serverA, read_file, { path: '/a.txt' })
+    const request = approvalService.createApprovalRequest('duckA', 'serverA', 'read_file', {
+      path: '/a.txt',
+    });
+    approvalService.approveRequest(request.id);
+
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__serverA__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'serverA',
+      _mcp_tool: 'read_file',
+      _approval_id: request.id,
+    });
+
+    expect(result.success).toBe(true);
+    expect(callToolSpy).toHaveBeenCalledTimes(1);
+    expect(callToolSpy).toHaveBeenCalledWith('serverA', 'read_file', { path: '/a.txt' });
+  });
+
+  it('(a) rejects when an approval ID is replayed for a different server/tool', async () => {
+    const callToolSpy = jest
+      .spyOn(mcpManager, 'callTool')
+      .mockResolvedValue({ ok: true });
+
+    // Approve for (duckA, serverA, read_file, argsX)
+    const request = approvalService.createApprovalRequest('duckA', 'serverA', 'read_file', {
+      path: '/a.txt',
+    });
+    approvalService.approveRequest(request.id);
+
+    // Replay the SAME id for a different server + destructive tool
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__serverB__delete_repo', {
+      _mcp_server: 'serverB',
+      _mcp_tool: 'delete_repo',
+      _approval_id: request.id,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    // The tool must NOT have executed
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it('(b) rejects when the same approval ID is replayed with different args', async () => {
+    const callToolSpy = jest
+      .spyOn(mcpManager, 'callTool')
+      .mockResolvedValue({ ok: true });
+
+    // Approve for (duckA, serverA, read_file, { path: '/a.txt' })
+    const request = approvalService.createApprovalRequest('duckA', 'serverA', 'read_file', {
+      path: '/a.txt',
+    });
+    approvalService.approveRequest(request.id);
+
+    // Same server/tool but DIFFERENT args
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__serverA__read_file', {
+      path: '/etc/shadow',
+      _mcp_server: 'serverA',
+      _mcp_tool: 'read_file',
+      _approval_id: request.id,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it('(d) rejects a fabricated/unknown approval ID (no such request)', async () => {
+    const callToolSpy = jest
+      .spyOn(mcpManager, 'callTool')
+      .mockResolvedValue({ ok: true });
+
+    // A prompt-injected duck invents an approval ID that was never issued.
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__serverA__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'serverA',
+      _mcp_tool: 'read_file',
+      _approval_id: 'totally-made-up-id',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it('(c) rejects reuse: a consumed approval ID is rejected on a second call', async () => {
+    const callToolSpy = jest
+      .spyOn(mcpManager, 'callTool')
+      .mockResolvedValue({ ok: true });
+
+    const request = approvalService.createApprovalRequest('duckA', 'serverA', 'read_file', {
+      path: '/a.txt',
+    });
+    approvalService.approveRequest(request.id);
+
+    const args = {
+      path: '/a.txt',
+      _mcp_server: 'serverA',
+      _mcp_tool: 'read_file',
+      _approval_id: request.id,
+    };
+
+    // First call: succeeds and consumes the approval
+    const first = await functionBridge.handleFunctionCall('duckA', 'mcp__serverA__read_file', {
+      ...args,
+    });
+    expect(first.success).toBe(true);
+
+    // Second call (replay/reuse): must be rejected, tool not executed again
+    const second = await functionBridge.handleFunctionCall('duckA', 'mcp__serverA__read_file', {
+      ...args,
+    });
+    expect(second.success).toBe(false);
+    expect(second.error).toBeDefined();
+
+    // callTool ran exactly once across both attempts
+    expect(callToolSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * AC-R5S9MH.1 — ApprovalService.consumeApproval single-use semantics.
+ */
+describe('ApprovalService.consumeApproval (AC-R5S9MH.1)', () => {
+  let service: ApprovalService;
+
+  beforeEach(() => {
+    service = new ApprovalService(300);
+  });
+
+  afterEach(() => {
+    service.shutdown();
+  });
+
+  it('marks an approved request as consumed (terminal)', () => {
+    const request = service.createApprovalRequest('duckA', 'serverA', 'read_file', {
+      path: '/a.txt',
+    });
+    service.approveRequest(request.id);
+    expect(service.getApprovalStatus(request.id)).toBe('approved');
+
+    const consumed = service.consumeApproval(request.id);
+    expect(consumed).toBe(true);
+    expect(service.getApprovalStatus(request.id)).toBe('consumed');
+  });
+
+  it('refuses to consume an already-consumed request', () => {
+    const request = service.createApprovalRequest('duckA', 'serverA', 'read_file', {
+      path: '/a.txt',
+    });
+    service.approveRequest(request.id);
+
+    expect(service.consumeApproval(request.id)).toBe(true);
+    expect(service.consumeApproval(request.id)).toBe(false);
+  });
+});

--- a/tests/logger-stdio.test.ts
+++ b/tests/logger-stdio.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+// IMPORTANT: do NOT mock ../src/utils/logger here — we need the real winston transport
+// to verify which OS stream (stdout vs stderr) each level is routed to.
+import { logger } from '../src/utils/logger';
+
+/**
+ * AC-R5S9MH.3 (H3) — stdio logging safety.
+ *
+ * The server always connects over stdio, so NO log line (any level) may ever be
+ * written to process.stdout — that channel carries framed JSON-RPC. All winston
+ * Console output must go to stderr instead.
+ */
+async function flush(): Promise<void> {
+  // Give winston's async transports a couple ticks to drain.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe('logger stdio safety (AC-R5S9MH.3)', () => {
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  function wroteSentinel(spy: jest.SpiedFunction<typeof process.stdout.write>, sentinel: string) {
+    return spy.mock.calls.some((call) => {
+      const chunk = call[0];
+      return typeof chunk === 'string' && chunk.includes(sentinel);
+    });
+  }
+
+  it('routes error logs to stderr, never stdout', async () => {
+    const sentinel = 'SENTINEL_ERROR_R5S9MH';
+    logger.error(sentinel);
+    await flush();
+
+    expect(wroteSentinel(stdoutSpy, sentinel)).toBe(false);
+    expect(wroteSentinel(stderrSpy, sentinel)).toBe(true);
+  });
+
+  it('routes warn logs to stderr, never stdout', async () => {
+    const sentinel = 'SENTINEL_WARN_R5S9MH';
+    logger.warn(sentinel);
+    await flush();
+
+    expect(wroteSentinel(stdoutSpy, sentinel)).toBe(false);
+    expect(wroteSentinel(stderrSpy, sentinel)).toBe(true);
+  });
+
+  it('routes info logs to stderr, never stdout', async () => {
+    const sentinel = 'SENTINEL_INFO_R5S9MH';
+    logger.info(sentinel);
+    await flush();
+
+    // This is the core H3 defect: winston's default Console transport sends
+    // info-level records to stdout. They must go to stderr instead.
+    expect(wroteSentinel(stdoutSpy, sentinel)).toBe(false);
+    expect(wroteSentinel(stderrSpy, sentinel)).toBe(true);
+  });
+});
+
+describe('welcome banner stdio safety (AC-R5S9MH.3)', () => {
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+  let logSpy: jest.SpiedFunction<typeof console.log>;
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('prints the welcome banner to stderr, never stdout', async () => {
+    // The implementer extracts the banner into an exported helper that writes to stderr.
+    const { printWelcomeBanner } = await import('../src/utils/banner');
+
+    printWelcomeBanner();
+
+    // The banner must not reach stdout via process.stdout.write OR console.log.
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+
+    // It must reach the user via stderr (console.error writes to process.stderr).
+    const wroteToStderr =
+      stderrSpy.mock.calls.length > 0 || errorSpy.mock.calls.length > 0;
+    expect(wroteToStderr).toBe(true);
+  });
+});

--- a/tests/multi-round-tools.test.ts
+++ b/tests/multi-round-tools.test.ts
@@ -439,6 +439,36 @@ describe('Multi-Round Tool Calling', () => {
     expect(result.content).toBe('Just a simple answer.');
     expect(result.toolRoundsUsed).toBeUndefined();
   });
+
+  // AC-R5S9MH.2 — principal wiring: the provider must pass its stable provider
+  // NAME (this.name === 'test'), not its human nickname (this.nickname === 'Test Duck'),
+  // as the duckName argument to functionBridge.handleFunctionCall. The principal is
+  // the provider name so two providers sharing a nickname cannot cross-authorize.
+  it('passes the provider name (not the nickname) as the duckName to handleFunctionCall', async () => {
+    const provider = createProvider();
+
+    jest
+      .spyOn(provider as any, 'createChatCompletion')
+      .mockResolvedValueOnce(
+        mockChatResponse({
+          tool_calls: [toolCall('tc1', 'mcp__fs__search', { query: 'x' })],
+        })
+      )
+      .mockResolvedValueOnce(mockChatResponse({ content: 'Done.' }));
+
+    const handleFnSpy = jest
+      .spyOn(functionBridge, 'handleFunctionCall')
+      .mockResolvedValue({ success: true, data: 'ok' });
+
+    await provider.chat({
+      messages: [{ role: 'user', content: 'search', timestamp: new Date() }],
+    });
+
+    expect(handleFnSpy).toHaveBeenCalled();
+    const [duckNameArg] = handleFnSpy.mock.calls[0];
+    expect(duckNameArg).toBe('test'); // provider name
+    expect(duckNameArg).not.toBe('Test Duck'); // not the nickname
+  });
 });
 
 describe('Multi-Round Tool Calling Config', () => {


### PR DESCRIPTION
## Summary
Milestone **M2** (FR R5S9MH) remediates the 5 HIGH-severity defects from the 2026-06-15 full-codebase review (`CODE-REVIEW-2026-06-15.md`), delivered as 4 atomic, security-first `fix:` commits.

- **H1/H2 — `fix(mcp-bridge)` (approval-gate security):** bind a duck-supplied `_approval_id` to its originating call (duck + server + tool + canonical args) and make IDs single-use (consumed after one successful execution); scope session approvals by **provider name + server + tool + sha256(canonical args)** with a TTL, switching the principal from display nickname to stable provider name. Closes a real approval-replay / cross-provider-reuse path. Adds `src/utils/canonical-json.ts`.
- **H3 — `fix(logger)`:** route the winston Console transport and the welcome banner to **stderr** (via a `Stream` transport + extracted `src/utils/banner.ts`) so stdio stdout carries only framed JSON-RPC, regardless of `MCP_SERVER`/`--mcp`.
- **H4 — `fix(config)`:** `getMCPBridgeConfig` preserves file-defined `mcp_servers`/`trusted_tools_by_server` when no env vars are set (env overwrites only when non-empty).
- **H5 — `fix(duck-iterate)`:** track the last *improvement* separately so `critique-improve` never returns a critique as the final response (including even `iterations`).

## Test plan
- [x] `npm run typecheck && npm run lint && npm test` → 0 errors, **52 suites / 1141 tests** pass (+27 new)
- [x] `npm run build` → clean (exit 0); new modules compiled to `dist/`
- [x] `/spec-review` → 5/5 ACs Done, 0 drift
- [x] Live **MCP smoke** on the rebuilt server: both providers healthy; MCP-bridge tool-calling end-to-end (fetch → real `<h1>`); `duck_iterate` critique-improve returns improvement not critique (AC5); 3 `mcp_servers` loaded (AC4); every call clean over stdio (AC3)
- [x] AC1/AC2 approval-gate binding / single-use / session-scope / TTL / principal verified against the compiled `dist/` (11/11)

## Follow-ups (advisory, non-blocking)
- Guardrail `modify` mutates tool args after the approval-binding check (not duck-exploitable — guardrail output is operator-configured server-side).
- `ApprovalService` cleanup `setInterval` is not `.unref()`'d (pre-existing).

Refs: M2 (AC-R5S9MH.1 … AC-R5S9MH.5)