### PR TITLE
Refresh LLM pricing (2026-07-14) and migrate default models off deprecated Groq/Gemini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ An MCP (Model Context Protocol) server that acts as a bridge to query multiple L
 
 Any provider with an OpenAI-compatible API endpoint, including:
 
-- **OpenAI** (GPT-5.1, o3, o4-mini)
-- **Google Gemini** (Gemini 3, Gemini 2.5 Pro/Flash)
+- **OpenAI**
+- **Google Gemini**
 - **Anthropic** (via OpenAI-compatible endpoints)
-- **Groq** (Llama 4, Llama 3.3)
-- **Together AI** (Llama 4, Qwen, and more)
-- **Perplexity** (Online models with web search)
+- **Groq** (fast inference for open-weight models)
+- **Together AI** (broad open-weight model catalog)
+- **Perplexity** (online models with web search)
 - **Anyscale**, **Azure OpenAI**, **Ollama**, **LM Studio**, **Custom**
 
 ### CLI Providers (Coding Agents)

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -11,16 +11,16 @@
     "gemini": {
       "api_key": "${GEMINI_API_KEY}",
       "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
-      "models": ["gemini-3-pro-preview", "gemini-2.5-pro", "gemini-2.5-flash"],
-      "default_model": "gemini-2.5-flash",
+      "models": ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite"],
+      "default_model": "gemini-3.5-flash",
       "nickname": "Gemini Duck",
       "temperature": 0.7
     },
     "groq": {
       "api_key": "${GROQ_API_KEY}",
       "base_url": "https://api.groq.com/openai/v1",
-      "models": ["meta-llama/llama-4-scout-17b-16e-instruct", "meta-llama/llama-4-maverick-17b-128e-instruct", "llama-3.3-70b-versatile"],
-      "default_model": "llama-3.3-70b-versatile",
+      "models": ["openai/gpt-oss-120b", "openai/gpt-oss-20b"],
+      "default_model": "openai/gpt-oss-120b",
       "nickname": "Groq Duck",
       "temperature": 0.7
     },

--- a/docs/claude-desktop.md
+++ b/docs/claude-desktop.md
@@ -105,7 +105,7 @@ Use the compare_ducks tool with prompt: "Explain async/await in JavaScript"
 
 ### Test Specific Models
 ```
-Use the ask_duck tool with prompt: "Hello", provider: "openai", model: "gpt-4o"
+Use the ask_duck tool with prompt: "Hello", provider: "openai", model: "gpt-5.1"
 ```
 
 ## Troubleshooting

--- a/docs/cli-providers.md
+++ b/docs/cli-providers.md
@@ -22,7 +22,7 @@ Each preset comes with sensible defaults for command, arguments, prompt delivery
 
 ```bash
 CLI_CLAUDE_NICKNAME=My Claude Agent
-CLI_CLAUDE_DEFAULT_MODEL=claude-sonnet-4-20250514
+CLI_CLAUDE_DEFAULT_MODEL=claude-sonnet-5
 CLI_CLAUDE_CLI_ARGS=--max-turns,5,--verbose
 CLI_CLAUDE_SYSTEM_PROMPT=Be concise and technical
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,11 +17,11 @@ OPENAI_DEFAULT_MODEL=gpt-5.1  # Optional: defaults to gpt-5.1
 
 # Google Gemini
 GEMINI_API_KEY=...
-GEMINI_DEFAULT_MODEL=gemini-2.5-flash  # Optional: defaults to gemini-2.5-flash
+GEMINI_DEFAULT_MODEL=gemini-3.5-flash  # Optional: defaults to gemini-3.5-flash
 
 # Groq
 GROQ_API_KEY=gsk_...
-GROQ_DEFAULT_MODEL=llama-3.3-70b-versatile  # Optional: defaults to llama-3.3-70b-versatile
+GROQ_DEFAULT_MODEL=openai/gpt-oss-120b  # Optional: defaults to openai/gpt-oss-120b
 
 # Ollama (Local)
 OLLAMA_BASE_URL=http://localhost:11434/v1  # Optional
@@ -51,7 +51,7 @@ CLI_AIDER_ENABLED=true                       # Aider
 
 # Optional overrides for preset CLI agents
 CLI_CLAUDE_NICKNAME=My Claude                # Optional: display name
-CLI_CLAUDE_DEFAULT_MODEL=claude-sonnet-4-20250514  # Optional: model override
+CLI_CLAUDE_DEFAULT_MODEL=claude-sonnet-5     # Optional: model override
 CLI_CLAUDE_SYSTEM_PROMPT=Be concise          # Optional: system prompt
 CLI_CLAUDE_CLI_ARGS=--max-turns,5,--verbose  # Optional: extra CLI args
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -144,8 +144,8 @@ export class ConfigManager {
         type: 'http' as const,
         api_key: process.env.GEMINI_API_KEY,
         base_url: 'https://generativelanguage.googleapis.com/v1beta/openai/',
-        models: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
-        default_model: process.env.GEMINI_DEFAULT_MODEL || 'gemini-2.5-flash',
+        models: ['gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite'],
+        default_model: process.env.GEMINI_DEFAULT_MODEL || 'gemini-3.5-flash',
         nickname: process.env.GEMINI_NICKNAME || 'Google Duck',
       };
     }
@@ -156,12 +156,8 @@ export class ConfigManager {
         type: 'http' as const,
         api_key: process.env.GROQ_API_KEY,
         base_url: 'https://api.groq.com/openai/v1',
-        models: [
-          'meta-llama/llama-4-scout-17b-16e-instruct',
-          'meta-llama/llama-4-maverick-17b-128e-instruct',
-          'llama-3.3-70b-versatile',
-        ],
-        default_model: process.env.GROQ_DEFAULT_MODEL || 'llama-3.3-70b-versatile',
+        models: ['openai/gpt-oss-120b', 'openai/gpt-oss-20b'],
+        default_model: process.env.GROQ_DEFAULT_MODEL || 'openai/gpt-oss-120b',
         nickname: process.env.GROQ_NICKNAME || 'Groq Duck',
       };
     }

--- a/src/data/default-pricing.ts
+++ b/src/data/default-pricing.ts
@@ -3,7 +3,7 @@ import { PricingConfig } from '../config/types.js';
 /**
  * Default pricing data for common LLM providers.
  * Prices are in USD per million tokens.
- * Last updated: 2026-06-05
+ * Last updated: 2026-07-14
  *
  * To update pricing:
  * 1. Research current pricing from provider websites
@@ -14,13 +14,19 @@ import { PricingConfig } from '../config/types.js';
  * Users can override these defaults in their config.json file.
  */
 export const DEFAULT_PRICING_VERSION = 2;
-export const DEFAULT_PRICING_LAST_UPDATED = '2026-06-05';
+export const DEFAULT_PRICING_LAST_UPDATED = '2026-07-14';
 
 export const DEFAULT_PRICING: PricingConfig = {
   openai: {
+    // GPT-5.6 models (released July 2026)
+    'gpt-5.6-sol': { inputPricePerMillion: 5, outputPricePerMillion: 30 },
+    'gpt-5.6-terra': { inputPricePerMillion: 2.5, outputPricePerMillion: 15 },
+    'gpt-5.6-luna': { inputPricePerMillion: 1, outputPricePerMillion: 6 },
+
     // GPT-5.5 models (premium tier, released April 2026)
     'gpt-5.5': { inputPricePerMillion: 5, outputPricePerMillion: 30 },
     'gpt-5.5-pro': { inputPricePerMillion: 30, outputPricePerMillion: 180 },
+    'gpt-5.5-cyber': { inputPricePerMillion: 12.5, outputPricePerMillion: 75 },
 
     // GPT-5.4 models (released March 2026)
     'gpt-5.4': { inputPricePerMillion: 2.5, outputPricePerMillion: 15 },
@@ -35,9 +41,12 @@ export const DEFAULT_PRICING: PricingConfig = {
     // GPT-5.2 models (deprecated, retiring June 5, 2026 - kept for compatibility)
     'gpt-5.2': { inputPricePerMillion: 1.75, outputPricePerMillion: 14 },
     'gpt-5.2-pro': { inputPricePerMillion: 21, outputPricePerMillion: 168 },
+    'gpt-5.2-chat-latest': { inputPricePerMillion: 1.75, outputPricePerMillion: 14 },
+    'gpt-5.2-codex': { inputPricePerMillion: 1.75, outputPricePerMillion: 14 },
 
     // GPT-5.1 models
     'gpt-5.1': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
+    'gpt-5.1-chat-latest': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
     'gpt-5.1-codex': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
     'gpt-5.1-codex-mini': { inputPricePerMillion: 0.25, outputPricePerMillion: 2 },
     'gpt-5.1-codex-max': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
@@ -47,6 +56,14 @@ export const DEFAULT_PRICING: PricingConfig = {
     'gpt-5-pro': { inputPricePerMillion: 15, outputPricePerMillion: 120 },
     'gpt-5-mini': { inputPricePerMillion: 0.25, outputPricePerMillion: 2 },
     'gpt-5-nano': { inputPricePerMillion: 0.05, outputPricePerMillion: 0.4 },
+    'gpt-5-chat-latest': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
+    'gpt-5-codex': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
+    'gpt-5-search-api': { inputPricePerMillion: 1.25, outputPricePerMillion: 10 },
+
+    // Floating aliases
+    'chat-latest': { inputPricePerMillion: 5, outputPricePerMillion: 30 },
+    'codex-mini-latest': { inputPricePerMillion: 1.5, outputPricePerMillion: 6 },
+    'chatgpt-4o-latest': { inputPricePerMillion: 5, outputPricePerMillion: 15 },
 
     // GPT-4.1 models
     'gpt-4.1': { inputPricePerMillion: 2, outputPricePerMillion: 8 },
@@ -60,22 +77,38 @@ export const DEFAULT_PRICING: PricingConfig = {
     'gpt-4o-2024-05-13': { inputPricePerMillion: 5, outputPricePerMillion: 15 },
     'gpt-4o-mini': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
     'gpt-4o-mini-2024-07-18': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
+    'gpt-4o-search-preview': { inputPricePerMillion: 2.5, outputPricePerMillion: 10 },
+    'gpt-4o-mini-search-preview': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
 
     // GPT-4 Turbo
     'gpt-4-turbo': { inputPricePerMillion: 10, outputPricePerMillion: 30 },
     'gpt-4-turbo-2024-04-09': { inputPricePerMillion: 10, outputPricePerMillion: 30 },
     'gpt-4-turbo-preview': { inputPricePerMillion: 10, outputPricePerMillion: 30 },
+    'gpt-4-0125-preview': { inputPricePerMillion: 10, outputPricePerMillion: 30 },
+    'gpt-4-1106-preview': { inputPricePerMillion: 10, outputPricePerMillion: 30 },
+    'gpt-4-1106-vision-preview': { inputPricePerMillion: 10, outputPricePerMillion: 30 },
 
     // GPT-4
     'gpt-4': { inputPricePerMillion: 30, outputPricePerMillion: 60 },
     'gpt-4-0613': { inputPricePerMillion: 30, outputPricePerMillion: 60 },
+    'gpt-4-0314': { inputPricePerMillion: 30, outputPricePerMillion: 60 },
+    'gpt-4-32k': { inputPricePerMillion: 60, outputPricePerMillion: 120 },
 
     // GPT-3.5 Turbo
     'gpt-3.5-turbo': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
     'gpt-3.5-turbo-0125': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
+    'gpt-3.5-turbo-1106': { inputPricePerMillion: 1, outputPricePerMillion: 2 },
+    'gpt-3.5-turbo-0613': { inputPricePerMillion: 1.5, outputPricePerMillion: 2 },
+    'gpt-3.5-0301': { inputPricePerMillion: 1.5, outputPricePerMillion: 2 },
+    'gpt-3.5-turbo-instruct': { inputPricePerMillion: 1.5, outputPricePerMillion: 2 },
+    'gpt-3.5-turbo-16k-0613': { inputPricePerMillion: 3, outputPricePerMillion: 4 },
+
+    // Base models
+    'davinci-002': { inputPricePerMillion: 2, outputPricePerMillion: 2 },
+    'babbage-002': { inputPricePerMillion: 0.4, outputPricePerMillion: 0.4 },
 
     // Computer use / specialized preview models
-    'computer-use-preview': { inputPricePerMillion: 1.5, outputPricePerMillion: 6 },
+    'computer-use-preview': { inputPricePerMillion: 3, outputPricePerMillion: 12 },
 
     // o4 reasoning models
     'o4-mini': { inputPricePerMillion: 1.1, outputPricePerMillion: 4.4 },
@@ -98,7 +131,16 @@ export const DEFAULT_PRICING: PricingConfig = {
   },
 
   anthropic: {
-    // Claude 4.8 models (current flagship)
+    // Claude Fable 5 / Mythos 5 (most capable tier)
+    'claude-fable-5': { inputPricePerMillion: 10, outputPricePerMillion: 50 },
+    'claude-mythos-5': { inputPricePerMillion: 10, outputPricePerMillion: 50 },
+
+    // Claude Sonnet 5
+    // NOTE: $2/$10 is the introductory rate, in effect through 2026-08-31.
+    // Reverts to the $3/$15 standard rate after that date - revisit on the next refresh.
+    'claude-sonnet-5': { inputPricePerMillion: 2, outputPricePerMillion: 10 },
+
+    // Claude 4.8 models
     'claude-opus-4-8': { inputPricePerMillion: 5, outputPricePerMillion: 25 },
 
     // Claude 4.7 models
@@ -128,16 +170,16 @@ export const DEFAULT_PRICING: PricingConfig = {
     'claude-sonnet-4': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
     'claude-sonnet-4-0': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
 
-    // Claude 3.7 models (deprecated but kept for compatibility)
+    // Claude 3.7 models (retired, kept for historical cost attribution)
     'claude-3-7-sonnet-20250219': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
     'claude-sonnet-3-7': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
 
-    // Claude 3.5 models
+    // Claude 3.5 models (retired, kept for historical cost attribution)
     'claude-3-5-sonnet-20241022': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
     'claude-3-5-haiku-20241022': { inputPricePerMillion: 0.8, outputPricePerMillion: 4 },
     'claude-haiku-3-5': { inputPricePerMillion: 0.8, outputPricePerMillion: 4 },
 
-    // Claude 3 models (deprecated but kept for compatibility)
+    // Claude 3 models (retired, kept for historical cost attribution)
     'claude-3-opus-20240229': { inputPricePerMillion: 15, outputPricePerMillion: 75 },
     'claude-opus-3': { inputPricePerMillion: 15, outputPricePerMillion: 75 },
     'claude-3-sonnet-20240229': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
@@ -148,15 +190,22 @@ export const DEFAULT_PRICING: PricingConfig = {
   google: {
     // Gemini 3.5
     'gemini-3.5-flash': { inputPricePerMillion: 1.5, outputPricePerMillion: 9 },
+    'gemini-3.5-live-translate-preview': { inputPricePerMillion: 3.5, outputPricePerMillion: 21 },
+
+    // Gemini Omni
+    'gemini-omni-flash-preview': { inputPricePerMillion: 1.5, outputPricePerMillion: 9 },
 
     // Gemini 3.1
-    'gemini-3.1-flash-lite': { inputPricePerMillion: 0.25, outputPricePerMillion: 1.5 },
     'gemini-3.1-pro-preview': { inputPricePerMillion: 2, outputPricePerMillion: 12 },
+    'gemini-3.1-flash-lite': { inputPricePerMillion: 0.25, outputPricePerMillion: 1.5 },
     'gemini-3.1-flash-lite-preview': { inputPricePerMillion: 0.25, outputPricePerMillion: 1.5 },
-    'gemini-3.1-flash-image-preview': { inputPricePerMillion: 0.5, outputPricePerMillion: 60 },
     'gemini-3.1-flash-live-preview': { inputPricePerMillion: 0.75, outputPricePerMillion: 4.5 },
+    'gemini-3.1-flash-image': { inputPricePerMillion: 0.5, outputPricePerMillion: 60 },
+    'gemini-3.1-flash-image-preview': { inputPricePerMillion: 0.5, outputPricePerMillion: 60 },
+    'gemini-3.1-flash-lite-image': { inputPricePerMillion: 0.25, outputPricePerMillion: 30 },
+    'gemini-3.1-flash-tts-preview': { inputPricePerMillion: 1, outputPricePerMillion: 20 },
 
-    // Gemini 3.0 (preview)
+    // Gemini 3.0
     'gemini-3-pro-preview': { inputPricePerMillion: 2, outputPricePerMillion: 12 },
     'gemini-3-flash-preview': { inputPricePerMillion: 0.5, outputPricePerMillion: 3 },
     'gemini-3-pro-image-preview': { inputPricePerMillion: 2, outputPricePerMillion: 120 },
@@ -168,7 +217,7 @@ export const DEFAULT_PRICING: PricingConfig = {
     'gemini-2.5-flash': { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
     'gemini-2.5-flash-latest': { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
     'gemini-2.5-flash-lite': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.4 },
-    'gemini-2.5-flash-image': { inputPricePerMillion: 0.3, outputPricePerMillion: 3 },
+    'gemini-2.5-flash-image': { inputPricePerMillion: 0.3, outputPricePerMillion: 30 },
     'gemini-2.5-flash-preview-09-2025': { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
     'gemini-2.5-flash-lite-preview-09-2025': {
       inputPricePerMillion: 0.1,
@@ -190,14 +239,14 @@ export const DEFAULT_PRICING: PricingConfig = {
     'gemini-2.0-flash-lite': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
     'gemini-2.0-flash-exp': { inputPricePerMillion: 0, outputPricePerMillion: 0 }, // Free during preview
 
-    // Gemini 1.5
+    // Gemini 1.5 (retired, kept for historical cost attribution)
     'gemini-1.5-pro': { inputPricePerMillion: 1.25, outputPricePerMillion: 5 },
     'gemini-1.5-pro-latest': { inputPricePerMillion: 1.25, outputPricePerMillion: 5 },
     'gemini-1.5-flash': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
     'gemini-1.5-flash-latest': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
     'gemini-1.5-flash-8b': { inputPricePerMillion: 0.0375, outputPricePerMillion: 0.15 },
 
-    // Gemini 1.0
+    // Gemini 1.0 (retired, kept for historical cost attribution)
     'gemini-1.0-pro': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
     'gemini-pro': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
 
@@ -206,17 +255,33 @@ export const DEFAULT_PRICING: PricingConfig = {
     'gemini-embedding-2': { inputPricePerMillion: 0.2, outputPricePerMillion: 0 },
 
     // Robotics (preview)
+    'gemini-robotics-er-1.6-preview': { inputPricePerMillion: 1, outputPricePerMillion: 5 },
     'gemini-robotics-er-1.5-preview': { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
 
-    // Gemma (free)
+    // Gemma (free tier only - no paid-tier price published)
     'gemma-3': { inputPricePerMillion: 0, outputPricePerMillion: 0 },
     'gemma-3n': { inputPricePerMillion: 0, outputPricePerMillion: 0 },
   },
 
   groq: {
-    // Llama 4
-    'llama-4-scout-17b-128k': { inputPricePerMillion: 0.11, outputPricePerMillion: 0.34 },
-    'llama-4-maverick-17b-128k': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.6 },
+    // Current API model IDs (as published on the Groq console models page)
+    'meta-llama/llama-4-scout-17b-16e-instruct': {
+      inputPricePerMillion: 0.11,
+      outputPricePerMillion: 0.34,
+    },
+    'openai/gpt-oss-120b': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
+    'openai/gpt-oss-20b': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
+    'openai/gpt-oss-safeguard-20b': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
+    'qwen/qwen3-32b': { inputPricePerMillion: 0.29, outputPricePerMillion: 0.59 },
+    'qwen/qwen3.6-27b': { inputPricePerMillion: 0.6, outputPricePerMillion: 3 },
+    'meta-llama/llama-prompt-guard-2-22m': {
+      inputPricePerMillion: 0.03,
+      outputPricePerMillion: 0.03,
+    },
+    'meta-llama/llama-prompt-guard-2-86m': {
+      inputPricePerMillion: 0.04,
+      outputPricePerMillion: 0.04,
+    },
 
     // Llama 3.3
     'llama-3.3-70b-versatile': { inputPricePerMillion: 0.59, outputPricePerMillion: 0.79 },
@@ -224,15 +289,13 @@ export const DEFAULT_PRICING: PricingConfig = {
     // Llama 3.1
     'llama-3.1-8b-instant': { inputPricePerMillion: 0.05, outputPricePerMillion: 0.08 },
 
-    // GPT-OSS models
+    // Legacy short names kept for compatibility (not current Groq API model IDs)
+    'llama-4-scout-17b-128k': { inputPricePerMillion: 0.11, outputPricePerMillion: 0.34 },
+    'llama-4-maverick-17b-128k': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.6 },
     'gpt-oss-120b-128k': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
     'gpt-oss-20b-128k': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
     'gpt-oss-safeguard-20b': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.3 },
-
-    // Qwen
     'qwen3-32b-131k': { inputPricePerMillion: 0.29, outputPricePerMillion: 0.59 },
-
-    // Kimi
     'kimi-k2-0905-256k': { inputPricePerMillion: 1, outputPricePerMillion: 3 },
 
     // Models below removed from current Groq pricing page but kept for compatibility
@@ -244,7 +307,7 @@ export const DEFAULT_PRICING: PricingConfig = {
   },
 
   deepseek: {
-    // DeepSeek V4 (current models, May 2026)
+    // DeepSeek V4 (current models). Input price is the cache-miss rate.
     'deepseek-v4-flash': { inputPricePerMillion: 0.14, outputPricePerMillion: 0.28 },
     'deepseek-v4-pro': { inputPricePerMillion: 0.435, outputPricePerMillion: 0.87 },
     // Legacy aliases (deepseek-chat / deepseek-reasoner map to v4-flash non-thinking/thinking modes)
@@ -263,12 +326,13 @@ export const DEFAULT_PRICING: PricingConfig = {
 
     // Mistral Medium 3.5 (current latest)
     'mistral-medium-latest': { inputPricePerMillion: 1.5, outputPricePerMillion: 7.5 },
+    'mistral-medium-3-5': { inputPricePerMillion: 1.5, outputPricePerMillion: 7.5 },
     'mistral-medium-3.5': { inputPricePerMillion: 1.5, outputPricePerMillion: 7.5 },
     'mistral-medium-3.1': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
     'mistral-medium-3': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
 
     // Mistral Small (4.0 / 3.x)
-    'mistral-small-latest': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.2 },
+    'mistral-small-latest': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
     'mistral-small-4': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
     'mistral-small-2603': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
     'mistral-small-3.2': { inputPricePerMillion: 0.075, outputPricePerMillion: 0.2 },
@@ -281,8 +345,12 @@ export const DEFAULT_PRICING: PricingConfig = {
     'mistral-saba': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.6 },
 
     // Magistral (reasoning)
+    'magistral-medium-latest': { inputPricePerMillion: 2, outputPricePerMillion: 5 },
+    'magistral-medium-2509': { inputPricePerMillion: 2, outputPricePerMillion: 5 },
     'magistral-medium': { inputPricePerMillion: 2, outputPricePerMillion: 5 },
     'magistral-medium-1.2': { inputPricePerMillion: 2, outputPricePerMillion: 5 },
+    'magistral-small-latest': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
+    'magistral-small-2509': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
     'magistral-small-1.2': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.5 },
 
     // Codestral
@@ -290,22 +358,27 @@ export const DEFAULT_PRICING: PricingConfig = {
     'codestral-2508': { inputPricePerMillion: 0.3, outputPricePerMillion: 0.9 },
     'codestral-2501': { inputPricePerMillion: 0.3, outputPricePerMillion: 0.9 },
 
-    // Codestral Embed
-    'codestral-embed': { inputPricePerMillion: 0.15, outputPricePerMillion: 0 },
-
-    // Devstral 2
-    'devstral-2': { inputPricePerMillion: 0.4, outputPricePerMillion: 0.9 },
-    'devstral-2512': { inputPricePerMillion: 0.4, outputPricePerMillion: 0.9 },
+    // Devstral
+    'devstral-latest': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
+    'devstral-medium-latest': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
+    'devstral-2512': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
     'devstral-medium': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
+    'devstral-small-latest': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
+    'labs-devstral-small-2512': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
+    'devstral-2': { inputPricePerMillion: 0.4, outputPricePerMillion: 2 },
     'devstral-small-2': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
     'devstral-small-1.1': { inputPricePerMillion: 0.07, outputPricePerMillion: 0.28 },
 
     // Ministral
+    'ministral-14b-latest': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.2 },
     'ministral-14b-2512': { inputPricePerMillion: 0.2, outputPricePerMillion: 0.2 },
     'ministral-8b-latest': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.15 },
     'ministral-8b-2512': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.15 },
     'ministral-3b-latest': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.1 },
     'ministral-3b-2512': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.1 },
+
+    // Leanstral (free during preview)
+    'labs-leanstral-2603': { inputPricePerMillion: 0, outputPricePerMillion: 0 },
 
     // Pixtral
     'pixtral-large-latest': { inputPricePerMillion: 2, outputPricePerMillion: 6 },
@@ -313,33 +386,48 @@ export const DEFAULT_PRICING: PricingConfig = {
     'pixtral-12b': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.1 },
 
     // Voxtral
+    // NOTE: mistral.ai/pricing lists $0.4 output; the model card lists $0.3. Kept at the
+    // model-card value pending clarification. Audio input is billed per minute, not per token.
     'voxtral-small-2507': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.3 },
+
+    // Embeddings
+    'codestral-embed': { inputPricePerMillion: 0.15, outputPricePerMillion: 0 },
+    'codestral-embed-2505': { inputPricePerMillion: 0.15, outputPricePerMillion: 0 },
+    'mistral-embed': { inputPricePerMillion: 0.1, outputPricePerMillion: 0 },
+    'mistral-embed-2312': { inputPricePerMillion: 0.1, outputPricePerMillion: 0 },
 
     // Mixtral
     'open-mixtral-8x7b': { inputPricePerMillion: 0.7, outputPricePerMillion: 0.7 },
     'open-mixtral-8x22b': { inputPricePerMillion: 2, outputPricePerMillion: 6 },
 
     // Open models
-    'open-mistral-nemo': { inputPricePerMillion: 0.02, outputPricePerMillion: 0.04 },
+    'open-mistral-nemo': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.15 },
   },
 
   together: {
-    // Current serverless lineup (April 2026)
-    'MiniMaxAI/MiniMax-M2.5': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
+    // Current serverless lineup
+    'MiniMaxAI/MiniMax-M3': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
     'MiniMaxAI/MiniMax-M2.7': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
-    'moonshotai/Kimi-K2.5': { inputPricePerMillion: 0.5, outputPricePerMillion: 2.8 },
+    'MiniMaxAI/MiniMax-M2.5': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
+    'moonshotai/Kimi-K2.7-Code': { inputPricePerMillion: 0.95, outputPricePerMillion: 4 },
     'moonshotai/Kimi-K2.6': { inputPricePerMillion: 1.2, outputPricePerMillion: 4.5 },
-    'deepseek-ai/DeepSeek-V4-Pro': { inputPricePerMillion: 2.1, outputPricePerMillion: 4.4 },
+    'moonshotai/Kimi-K2.5': { inputPricePerMillion: 0.5, outputPricePerMillion: 2.8 },
+    'deepseek-ai/DeepSeek-V4-Pro': { inputPricePerMillion: 1.74, outputPricePerMillion: 3.48 },
+    'zai-org/GLM-5.2': { inputPricePerMillion: 1.4, outputPricePerMillion: 4.4 },
     'zai-org/GLM-5.1': { inputPricePerMillion: 1.4, outputPricePerMillion: 4.4 },
     'zai-org/GLM-5': { inputPricePerMillion: 1, outputPricePerMillion: 3.2 },
+    'nvidia/nemotron-3-ultra-550b-a55b': { inputPricePerMillion: 0.6, outputPricePerMillion: 3.6 },
     'google/gemma-4-31B-it': { inputPricePerMillion: 0.39, outputPricePerMillion: 0.97 },
-    'Qwen/Qwen3.6-Plus': { inputPricePerMillion: 0.5, outputPricePerMillion: 3 },
+    'pearl-ai/gemma-4-31b-it': { inputPricePerMillion: 0.28, outputPricePerMillion: 0.86 },
     'Qwen/Qwen3.7-Max': { inputPricePerMillion: 1.25, outputPricePerMillion: 3.75 },
+    'Qwen/Qwen3.7-Plus': { inputPricePerMillion: 0.32, outputPricePerMillion: 1.28 },
+    'Qwen/Qwen3.6-Plus': { inputPricePerMillion: 0.5, outputPricePerMillion: 3 },
+    'Qwen/Qwen3.5-397B-A17B': { inputPricePerMillion: 0.6, outputPricePerMillion: 3.6 },
+    'Qwen/Qwen3.5-9B': { inputPricePerMillion: 0.17, outputPricePerMillion: 0.25 },
     'openai/gpt-oss-120b': { inputPricePerMillion: 0.15, outputPricePerMillion: 0.6 },
     'openai/gpt-oss-20b': { inputPricePerMillion: 0.05, outputPricePerMillion: 0.2 },
+    'LiquidAI/LFM2.5-8B-A1B': { inputPricePerMillion: 0.03, outputPricePerMillion: 0.12 },
     'LiquidAI/LFM2-24B-A2B': { inputPricePerMillion: 0.03, outputPricePerMillion: 0.12 },
-    'Qwen/Qwen3.5-397B-A17B': { inputPricePerMillion: 0.6, outputPricePerMillion: 3.6 },
-    'Qwen/Qwen3.5-9B': { inputPricePerMillion: 0.1, outputPricePerMillion: 0.15 },
     'Qwen/Qwen3-Coder-Next-FP8': { inputPricePerMillion: 0.5, outputPricePerMillion: 1.2 },
     'Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8': {
       inputPricePerMillion: 2,
@@ -349,6 +437,7 @@ export const DEFAULT_PRICING: PricingConfig = {
       inputPricePerMillion: 0.2,
       outputPricePerMillion: 0.6,
     },
+    'Qwen/Qwen2.5-7B-Instruct-Turbo': { inputPricePerMillion: 0.3, outputPricePerMillion: 0.3 },
     'deepseek-ai/DeepSeek-V3.1': { inputPricePerMillion: 0.6, outputPricePerMillion: 1.7 },
     'deepseek-ai/DeepSeek-R1': { inputPricePerMillion: 3, outputPricePerMillion: 7 },
     'deepcogito/cogito-v2-1-671b': { inputPricePerMillion: 1.25, outputPricePerMillion: 1.25 },
@@ -385,6 +474,10 @@ export const DEFAULT_PRICING: PricingConfig = {
     },
 
     // Llama 3
+    'meta-llama/Meta-Llama-3-8B-Instruct-Lite': {
+      inputPricePerMillion: 0.14,
+      outputPricePerMillion: 0.14,
+    },
     'meta-llama/Llama-3-8B-Instruct-Lite': {
       inputPricePerMillion: 0.1,
       outputPricePerMillion: 0.1,
@@ -430,20 +523,19 @@ export const DEFAULT_PRICING: PricingConfig = {
     'Qwen/Qwen2.5-72B-Instruct-Turbo': { inputPricePerMillion: 1.2, outputPricePerMillion: 1.2 },
     'Qwen/Qwen2.5-VL-72B-Instruct': { inputPricePerMillion: 1.95, outputPricePerMillion: 8 },
     'Qwen/Qwen2.5-Coder-32B-Instruct': { inputPricePerMillion: 0.8, outputPricePerMillion: 0.8 },
-    'Qwen/Qwen2.5-7B-Instruct-Turbo': { inputPricePerMillion: 0.3, outputPricePerMillion: 0.3 },
     'Qwen/QwQ-32B': { inputPricePerMillion: 1.2, outputPricePerMillion: 1.2 },
 
-    // Kimi
+    // Kimi (legacy short names, kept for compatibility)
     'Kimi/K2-Instruct': { inputPricePerMillion: 1, outputPricePerMillion: 3 },
     'Kimi/K2-Thinking': { inputPricePerMillion: 1.2, outputPricePerMillion: 4 },
     'Kimi/K2-0905': { inputPricePerMillion: 1, outputPricePerMillion: 3 },
     'Kimi/K2.5': { inputPricePerMillion: 0.5, outputPricePerMillion: 2.8 },
     'Kimi/K2.6': { inputPricePerMillion: 1.2, outputPricePerMillion: 4.5 },
 
-    // MiniMax
+    // MiniMax (legacy short name)
     'MiniMax/MiniMax-M2.5': { inputPricePerMillion: 0.3, outputPricePerMillion: 1.2 },
 
-    // GLM
+    // GLM (legacy short names, kept for compatibility)
     'THUDM/GLM-5': { inputPricePerMillion: 1, outputPricePerMillion: 3.2 },
     'THUDM/GLM-4.7': { inputPricePerMillion: 0.45, outputPricePerMillion: 2 },
     'THUDM/GLM-4.6': { inputPricePerMillion: 0.6, outputPricePerMillion: 2.2 },


### PR DESCRIPTION
## Why

The pricing table was last refreshed on 2026-06-05 and had drifted. While verifying it, a bigger problem surfaced: **two of the three hardcoded default models are on published vendor shutdown schedules.** Anyone who sets only an API key and never picks a model would have started hard-failing next month.

## What changed

### Pricing (`fix:` — patch)
Every entry fetched from the provider's official pricing page and independently re-verified before being written. Nothing carried over from memory.

- **+66 models** (330 total). Anthropic was missing `claude-fable-5`, `claude-mythos-5` and `claude-sonnet-5` entirely.
- **7 corrected prices** that were silently misreporting cost:

| model | was | now | |
|---|---|---|---|
| `openai/computer-use-preview` | 1.5 / 6 | **3 / 12** | old value was the *batch* rate |
| `google/gemini-2.5-flash-image` | 0.3 / 3 | **0.3 / 30** | output was off by 10x |
| `mistral/mistral-small-latest` | 0.075 / 0.2 | **0.15 / 0.6** | |
| `mistral/open-mistral-nemo` | 0.02 / 0.04 | **0.15 / 0.15** | repriced upward ~7x |
| `mistral/devstral-2512` + `devstral-2` | 0.4 / 0.9 | **0.4 / 2** | |
| `together/DeepSeek-V4-Pro` | 2.1 / 4.4 | **1.74 / 3.48** | price cut |
| `together/Qwen3.5-9B` | 0.1 / 0.15 | **0.17 / 0.25** | |

- **Zero models removed.** Retired models keep their prices, so historical cost attribution still resolves.

### Default models (`feat:` — minor)

| provider | old default | status | new default |
|---|---|---|---|
| groq | `llama-3.3-70b-versatile` | **shuts down 2026-08-16** | `openai/gpt-oss-120b` |
| google | `gemini-2.5-flash` | **shuts down 2026-10-16** | `gemini-3.5-flash` |
| openai | `gpt-5.1` | not deprecated | *unchanged* |

Both replacements are the ones each vendor explicitly names, and both are GA/production tier. Groq's deprecation notice scopes the shutdown to free and developer tier — exactly who a library default serves.

`gpt-5.1` stays: it has no published shutdown date, and its only same-tier successor (`gpt-5.6-sol`) costs 4x input / 3x output while still returning "model not available" on some paid tiers a week into GA.

Also refreshed the `models[]` lists and `config.example.json`, which advertised `gemini-2.5-pro` (same October shutdown) and two Groq models that are gone or going — **one of which shuts down in three days**.

## ⚠️ Cost impact — worth calling out in the release notes

The Groq swap is **cheaper** ($0.59/$0.79 → $0.15/$0.60). The Gemini swap is **not**: it's a **5x input / 3.6x output** rise ($0.30/$2.50 → $1.50/$9.00), and `gemini-3.5-flash` is a thinking model whose thinking tokens bill as output, so the effective rise is higher. Users can pin the old model via `GEMINI_DEFAULT_MODEL` until the October shutdown.

## Verification

Everything was checked twice: a fan-out of research agents per provider, then a **second, independent adversarial pass** that re-fetched every price change, shutdown date and model id from source rather than trusting the first run.

That second pass paid for itself — it caught three defects the first pass missed, all fixed here:
1. The Groq `models[]` still listed `meta-llama/llama-4-scout-17b-16e-instruct`, **which stops serving on 2026-07-17**.
2. `config/config.example.json` still shipped the pre-migration defaults, so following the updated docs landed you on the old models.
3. `devstral-2` was left at the old output rate while its alias `devstral-2512` moved, so the two names for one model billed differently.

It also rejected data that did *not* meet the evidence bar: a hallucinated Together model id, three OpenAI embedding entries whose output price was inferred rather than published, and Mistral's `voxtral-small` (two official pages disagree — left at the model-card value with a comment).

Green: `typecheck` · `lint` · `build` · 1141/1141 tests (52 suites) · server completes an MCP `initialize` handshake against the fresh build.

## Follow-ups (not in this PR)

- **2026-08-31:** `claude-sonnet-5`'s introductory $2/$10 reverts to $3/$15. Noted inline; the table has no expiry mechanism.
- **~Sept 2026:** revisit `gpt-5.6-sol` for the OpenAI default once its rollout settles.
- **Pre-existing:** `config.example.json` names the provider `gemini` while the pricing section is `google`, and `PROVIDER_ALIASES` is empty — so cost tracking returns `null` for anyone who copies that example. Not introduced here, but worth its own fix.
- `gemini-3.1-pro-preview` in `models[]` is preview-tier (Google's own named replacement for 2.5-pro, but non-durable by their policy).