### PR TITLE
fix(deps): clear audit-ci advisories and harden CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,22 @@
 # repo's existing posture: it relies on GitHub's repo-level Dependabot *security*
 # updates plus the audit-ci CI gate (audit-ci.json), not scheduled version bumps.
 #
-# `undici` is ignored entirely. Every copy in the tree is a transitive,
-# dev/release-only dependency (via the semantic-release toolchain). The only
-# unpatched one — undici@6.26.0 — is bundled inside the npm CLI tarball
-# (npm -> node-gyp -> undici), so it cannot be lifted by package overrides and no
-# patched npm release exists yet (node-gyp still requires undici ^6.25.0).
-# Dependabot's repeated security-update attempts therefore fail by construction.
-# The audit-ci gate tracks this advisory independently and goes green on its own
-# once npm ships a bundle with undici >= 6.27.0 — at which point this ignore can
-# be removed. See audit-ci.json's allowlist for the matching scoped suppression.
+# `undici` is ignored because its resolution is fully governed by the `overrides`
+# block in package.json (`undici@6.x` and `undici@7.x`), which Dependabot does not
+# edit. There are three copies in the tree:
+#   node_modules/undici                                6.28.0  <- @actions/http-client ^6.23.0
+#   node_modules/semantic-release/node_modules/undici  7.29.0  <- @semantic-release/github ^7.0.0
+#   node_modules/npm/node_modules/undici               6.27.0  <- bundled in the npm CLI tarball
+# The first two are already at the head of their major lines and are raised by
+# bumping the override floor, not by a Dependabot PR. The third is bundled inside
+# npm's own tarball and cannot be lifted by overrides at all. So every Dependabot
+# security-update attempt here is either a no-op or fails by construction — which
+# is what it did historically (see the closed PRs #84 and #85).
+#
+# audit-ci is the real gate and tracks these independently: audit-ci.json
+# allowlists the three bundled-npm undici advisories with re-check triggers.
+# Remove this ignore if undici ever becomes a direct dependency, or if the
+# overrides are dropped.
 version: 2
 updates:
   - package-ecosystem: "npm"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,22 +9,33 @@ on:
     # Run weekly security scans
     - cron: '0 6 * * 1'
 
+# Least privilege by default; jobs opt into more only where they need it.
 permissions:
   contents: read
-  security-events: write
-  actions: read
+
+# Supersede in-flight runs for the same ref — these are checks, not releases.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   security-scan:
     name: 🔍 Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🔒 Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # Pinned to the v0.36.0 tag commit — @master is a mutable ref.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -46,7 +57,7 @@ jobs:
 
       - name: 🔒 Run Trivy on Docker image
         if: github.event_name != 'schedule'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'security-scan-image'
           format: 'sarif'
@@ -63,13 +74,18 @@ jobs:
   dependency-check:
     name: 📦 Dependency Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -88,15 +104,22 @@ jobs:
         # audit-ci respects the allowlist in audit-ci.json — advisories with no
         # reachable fix (bundled/unpatched transitive dev deps). Each entry carries
         # a rationale + re-check trigger in $allowlist-rationale.
-        run: npx audit-ci --config audit-ci.json
+        # Version-pinned so the gate itself cannot shift under us.
+        run: npx --yes audit-ci@7.1.0 --config audit-ci.json
 
   dockerfile-lint:
     name: 🐳 Dockerfile Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🔍 Lint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
@@ -116,13 +139,18 @@ jobs:
   test:
     name: 🧪 Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -145,8 +173,11 @@ jobs:
   quality-gates:
     name: 🚀 Quality Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [security-scan, dependency-check, dockerfile-lint, test]
     if: always()
+    permissions:
+      contents: read
 
     steps:
       - name: 📊 Quality Gate Summary
@@ -180,3 +211,11 @@ jobs:
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📋 **View detailed results in the Security tab**" >> $GITHUB_STEP_SUMMARY
+
+      - name: 🚦 Enforce quality gates
+        # Without this the job is summary-only and always green, so a red
+        # dependency check or test suite would not fail this check.
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::One or more quality gates failed — see the job summary above"
+          exit 1

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,25 +11,30 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Least privilege by default; jobs opt into more only where they need it.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  packages: write
-  security-events: write
-  actions: read
-  id-token: write
+  contents: read
+
+# Never cancel an in-flight release; queue instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   test:
     name: 🧪 Test Before Release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -52,13 +57,20 @@ jobs:
   security-scan:
     name: 🔍 Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🔒 Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # Pinned to the v0.36.0 tag commit — @master is a mutable ref.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -77,7 +89,8 @@ jobs:
           docker build -t security-scan-image .
 
       - name: 🔒 Run Trivy on Docker image
-        uses: aquasecurity/trivy-action@master
+        # Pinned to the v0.36.0 tag commit — @master is a mutable ref.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'security-scan-image'
           format: 'sarif'
@@ -93,13 +106,18 @@ jobs:
   dependency-check:
     name: 📦 Dependency Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -118,15 +136,22 @@ jobs:
         # audit-ci respects the allowlist in audit-ci.json — advisories with no
         # reachable fix (bundled/unpatched transitive dev deps). Each entry carries
         # a rationale + re-check trigger in $allowlist-rationale.
-        run: npx audit-ci --config audit-ci.json
+        # Version-pinned so the gate itself cannot shift under us.
+        run: npx --yes audit-ci@7.1.0 --config audit-ci.json
 
   dockerfile-lint:
     name: 🐳 Dockerfile Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🔍 Lint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
@@ -147,19 +172,25 @@ jobs:
     name: 📦 Release
     needs: [test, security-scan, dependency-check, dockerfile-lint]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     outputs:
       release-version: ${{ steps.get-version.outputs.version }}
       new-release-published: ${{ steps.check-release.outputs.released }}
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -245,23 +276,27 @@ jobs:
     name: 🐳 Build & Push Docker Images
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
     if: needs.release.outputs.new-release-published == 'true'
 
     steps:
       - name: 📥 Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: v${{ needs.release.outputs.release-version }}
           fetch-depth: 0
 
       - name: 🛠️ Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🔑 Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -269,7 +304,7 @@ jobs:
 
       - name: 🏷️ Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -284,7 +319,7 @@ jobs:
 
       - name: 🐳 Build and push Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,19 +1,22 @@
 # Trivy ignore file.
 #
-# The four advisories below all map to undici bundled inside the npm CLI tarball
-# (npm -> node-gyp -> undici). It reaches package-lock.json only via the
-# dev/release-only semantic-release toolchain and is NOT in the runtime Docker
-# image (the production stage removes the npm CLI entirely). The bundled copy
-# cannot be lifted by package overrides.
+# Currently empty — no suppressions are needed.
 #
-# STATUS: npm now bundles the patched undici 6.27.0, so the matching audit-ci.json
-# allowlist entries were removed in 9b12879 (audit-ci's allowlist today holds
-# unrelated brace-expansion/tar advisories — it no longer mirrors this file).
-# These four lines and the .github/dependabot.yml ignore survive only because
-# Trivy scans package-lock.json, which still carries an orphaned undici 6.21.0
-# entry that is absent from the installed tree (`npm ls undici`). Remove both once
-# that lock entry is gone — verify the Trivy fs scan passes without them first.
-CVE-2026-12151
-CVE-2026-9679
-CVE-2026-11525
-CVE-2026-6733
+# This file previously suppressed four undici advisories (CVE-2026-12151,
+# CVE-2026-9679, CVE-2026-11525, CVE-2026-6733). All four are fixed in undici
+# 6.27.0 / 7.28.0 / 8.5.0, and every undici copy in the tree now meets that bar
+# (node_modules/undici 6.28.0, semantic-release's 7.29.0, and npm's bundled
+# 6.27.0), so the lines matched nothing and were removed.
+#
+# Their stated removal trigger was also unreachable: the comment said to drop
+# them "once the orphaned undici 6.21.0 lock entry is gone", but no such entry
+# has ever existed in this repo's lock. The 6.21.0 in package-lock.json is
+# `undici-types` — a types-only package with no runtime code.
+#
+# Note that npm's *bundled* copies of undici, tar, brace-expansion and
+# ip-address do still carry live advisories. Those are tracked deliberately in
+# audit-ci.json's allowlist (with per-advisory rationale and re-check triggers)
+# and are stripped from the runtime Docker image, which removes the npm CLI
+# entirely (see Dockerfile). If Trivy starts reporting them against
+# package-lock.json, mirror the audit-ci.json entries here rather than
+# re-adding the undici CVEs above.

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -5,8 +5,27 @@
   "critical": true,
   "report-type": "summary",
   "$allowlist-rationale": {
-    "GHSA-mh99-v99m-4gvg": "brace-expansion DoS. Dev-only, via three paths. (1) minimatch 3 (eslint, jest) -> 1.1.16 and (2) minimatch 9 (typescript-eslint) -> 2.1.2: patched only in 5.0.8, the 1.x/2.x lines have no backport, and forcing 5.x breaks them (v5 CJS exports {expand} instead of the function itself, so minimatch 3 throws 'expand is not a function'). (3) the npm CLI bundles minimatch 10 -> brace-expansion 5.0.7, one patch short, inside its own tarball where overrides cannot reach. Re-check when eslint/jest move to minimatch 10 (clears 1+2) and when npm rebundles brace-expansion >= 5.0.8 (clears 3).",
-    "GHSA-r292-9mhp-454m": "node-tar DoS. Dev/release-only: bundled inside the npm CLI tarball pulled in by semantic-release. Patched in tar 7.5.21 (2026-07-21); the latest npm (12.0.1) still bundles 7.5.19, and bundled deps are unreachable by overrides. Clearing this needs BOTH an npm release bundling tar >= 7.5.21 AND the `npm` override in package.json raised to allow it — it currently pins ^11.16.0, so a fix that lands only in npm 12.x would not be picked up."
+    "$root-cause": "Every entry below resolves to a dependency BUNDLED INSIDE THE npm CLI TARBALL (node_modules/npm/node_modules/*). npm publishes those via bundleDependencies, so `overrides` in package.json cannot reach them — verified: the undici/ip-address/brace-expansion overrides added on 2026-08-10 lifted every other copy in the tree but left npm's bundled ones untouched. The npm CLI is dev/release-only (devDependencies -> semantic-release -> @semantic-release/npm -> npm) and is stripped from the runtime Docker image. Checked on 2026-08-10 that npm 11.18.0, 11.19.0 AND 12.0.2 all bundle the SAME stale set: undici 6.27.0, tar 7.5.19, brace-expansion 5.0.7, ip-address 10.2.0, minimatch 10.2.5 — so bumping the `npm` override clears nothing today. Note @semantic-release/npm@13.1.5 declares `npm: ^11.6.2`, so a fix landing only in npm 12.x would additionally need the `npm` override raised past ^11.16.0.",
+    "$scoping": "Entries are path-scoped (`GHSA-ID|path`) rather than bare advisory IDs so a REACHABLE reintroduction of the same advisory still fails CI. This works for ip-address: the bundled copy renders as `ip-address` while the reachable one renders as `express-rate-limit>ip-address` (the path that was failing before this fix). It does NOT discriminate for undici and brace-expansion — audit-ci renders both the bundled and a hypothetical direct copy as the bare package name — so those two remain the weak spot; re-check them by hand when the tree changes. Path-scoped entries fail CLOSED: if npm audit's graph shifts, the string stops matching and CI goes red, which is the intended prompt to revisit this file.",
+    "GHSA-mh99-v99m-4gvg": "brace-expansion DoS (unbounded expansion length). Patched in 5.0.8. Only npm's bundled 5.0.7 is still affected. The previous rationale here claimed the 1.x/2.x lines had no backport — that is now STALE: 1.1.18 and 2.1.4 shipped, and the `brace-expansion@1.x`/`@2.x` overrides pin them, clearing the eslint/jest (minimatch 3) and typescript-eslint (minimatch 9) paths. Re-check when npm rebundles brace-expansion >= 5.0.9.",
+    "GHSA-rgw5-rvv9-x895": "brace-expansion DoS (unbounded intermediate arrays, bypasses the CVE-2026-14257 mitigation). Same bundled 5.0.7 as above; patched in 5.0.9. Same re-check trigger.",
+    "GHSA-mwp4-54f8-5fhr": "ip-address: leading-zero octets decoded as decimal (SSRF / trust-boundary bypass). Patched in 10.3.1. Reachable path (express-rate-limit -> ip-address) is fixed by the `ip-address` override at ^10.3.1; only npm's bundled 10.2.0 (via its vendored socks) remains. Re-check when npm rebundles ip-address >= 10.3.1.",
+    "GHSA-4xrf-jv44-h6hh": "ip-address: a CIDR suffix suppresses special-use classification (SSRF / trust-boundary bypass). Patched in 10.2.2. Same bundled-only path and re-check trigger as GHSA-mwp4-54f8-5fhr.",
+    "GHSA-22jq-vg5j-6vgg": "ip-address: IPv4-mapped/NAT64 IPv6 misclassification (SSRF / trust-boundary bypass). Patched in 10.2.1. Same bundled-only path and re-check trigger as GHSA-mwp4-54f8-5fhr.",
+    "GHSA-8xcm-r25x-g524": "undici: downstream response desynchronization via the retry interceptor. Patched in 6.28.0 / 7.29.0. The two reachable copies (@actions/http-client -> undici ^6.23.0, and @semantic-release/github -> undici ^7.0.0) are lifted by the `undici@6.x`/`@7.x` overrides; only npm's bundled 6.27.0 (via its vendored node-gyp) remains. Re-check when npm rebundles undici >= 6.28.0.",
+    "GHSA-m8rv-5g2x-5cg5": "undici: CRLF injection via a blob-like body `type` property. Patched in 6.28.0 / 7.29.0. Same bundled-only path and re-check trigger as GHSA-8xcm-r25x-g524.",
+    "GHSA-v3r7-h72x-cjcm": "undici: cookie attribute injection via unsanitized domain and unparsed setCookie fields. Patched in 6.28.0 / 7.29.0. Same bundled-only path and re-check trigger as GHSA-8xcm-r25x-g524.",
+    "GHSA-r292-9mhp-454m": "node-tar DoS (uncontrolled recursion in mapHas/filesFilter). Patched in tar 7.5.21 (latest 7.5.22); npm 12.0.2 still bundles 7.5.19. Re-check when npm rebundles tar >= 7.5.21 — and note the `npm: ^11.16.0` override caveat in $root-cause if the fix lands only in npm 12.x."
   },
-  "allowlist": ["GHSA-mh99-v99m-4gvg", "GHSA-r292-9mhp-454m"]
+  "allowlist": [
+    "GHSA-mh99-v99m-4gvg|brace-expansion",
+    "GHSA-rgw5-rvv9-x895|brace-expansion",
+    "GHSA-mwp4-54f8-5fhr|ip-address",
+    "GHSA-4xrf-jv44-h6hh|ip-address",
+    "GHSA-22jq-vg5j-6vgg|ip-address",
+    "GHSA-8xcm-r25x-g524|undici",
+    "GHSA-m8rv-5g2x-5cg5|undici",
+    "GHSA-v3r7-h72x-cjcm|undici",
+    "GHSA-r292-9mhp-454m|semantic-release>@semantic-release/npm>npm>tar"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3511,9 +3511,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3665,9 +3665,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4143,9 +4143,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5699,12 +5699,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5754,9 +5755,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6335,9 +6336,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6617,9 +6618,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7475,9 +7476,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8341,9 +8342,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -11921,9 +11922,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13165,9 +13166,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13241,9 +13242,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -74,16 +74,21 @@
     "@hono/node-server": "Major-version override (2.x) against the MCP SDK's declared ^1.19.9 — GHSA-frvp-7c67-39w9 is patched only in 2.0.5 and the 1.x line has no fix. Safe here: the SDK pulls @hono/node-server in for its server-side streamableHttp transport, which this project never imports (we use StreamableHTTPClientTransport, the client side, in src/services/mcp-client-manager.ts). v2 keeps the same serve/getRequestListener API. Revisit if this project ever serves MCP over HTTP, or drop the override once the SDK moves to ^2."
   },
   "overrides": {
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "lodash": "^4.17.23",
     "lodash-es": "^4.17.23",
-    "hono": "^4.12.27",
+    "hono": "^4.13.1",
     "@hono/node-server": "^2.0.5",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "postcss": "^8.5.18",
-    "ip-address": "^10.2.0",
+    "ip-address": "^10.3.1",
+    "express-rate-limit": "^8.6.2",
     "qs": "^6.15.2",
     "npm": "^11.16.0",
-    "brace-expansion@1.x": "^1.1.16"
+    "nanoid@3.x": "^3.3.17",
+    "undici@6.x": "^6.28.0",
+    "undici@7.x": "^7.29.0",
+    "brace-expansion@1.x": "^1.1.18",
+    "brace-expansion@2.x": "^2.1.4"
   }
 }

--- a/tests/function-bridge.test.ts
+++ b/tests/function-bridge.test.ts
@@ -193,3 +193,127 @@ describe('ApprovalService.consumeApproval (AC-R5S9MH.1)', () => {
     expect(service.consumeApproval(request.id)).toBe(false);
   });
 });
+
+/**
+ * Tool-argument schema validation (FunctionBridge.validateToolArguments).
+ *
+ * Exercised through the public surface: getFunctionDefinitions() caches each
+ * MCP tool's inputSchema, then handleFunctionCall() validates the cleaned args
+ * against it before dispatching to the MCP server.
+ *
+ * This is the project's only Ajv surface, and Ajv resolves `$ref` URIs through
+ * fast-uri — so these tests also pin the behaviour that the `fast-uri` override
+ * in package.json governs. Approval mode is 'never' so every call reaches the
+ * validation branch without an approval round-trip.
+ */
+describe('FunctionBridge tool-argument validation', () => {
+  let approvalService: ApprovalService;
+  let mcpManager: MCPClientManager;
+  let functionBridge: FunctionBridge;
+
+  const toolWithRefSchema = {
+    serverName: 'files',
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { $ref: '#/$defs/nonEmptyString' },
+        maxBytes: { type: 'integer', minimum: 1 },
+      },
+      required: ['path'],
+      $defs: {
+        nonEmptyString: { type: 'string', minLength: 1 },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    approvalService = new ApprovalService(300);
+    mcpManager = new MCPClientManager([]);
+    functionBridge = new FunctionBridge(mcpManager, approvalService, [], 'never');
+
+    jest.spyOn(mcpManager, 'listAllTools').mockResolvedValue([toolWithRefSchema]);
+    // Populates the internal schema cache keyed by `${serverName}:${name}`
+    await functionBridge.getFunctionDefinitions();
+  });
+
+  afterEach(() => {
+    approvalService.shutdown();
+    jest.restoreAllMocks();
+  });
+
+  it('compiles a $ref/$defs schema and accepts valid arguments', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/etc/hosts',
+      maxBytes: 1024,
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'read_file', {
+      path: '/etc/hosts',
+      maxBytes: 1024,
+    });
+  });
+
+  it('rejects arguments that violate the schema and does not call the tool', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+
+    // `path` resolves through $ref to { minLength: 1 } — an empty string fails
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid arguments for files:read_file');
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing required property', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      maxBytes: 10,
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid arguments for files:read_file');
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it("strips unknown properties before dispatch (Ajv removeAdditional: 'all')", async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/etc/hosts',
+      smuggled: 'should-not-reach-the-server',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'read_file', { path: '/etc/hosts' });
+  });
+
+  it('skips validation when no schema is cached for the tool', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+
+    // `files:write_file` was never returned by listAllTools, so no schema exists
+    const result = await functionBridge.handleFunctionCall('duckA', 'mcp__files__write_file', {
+      anything: 123,
+      _mcp_server: 'files',
+      _mcp_tool: 'write_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'write_file', { anything: 123 });
+  });
+});


### PR DESCRIPTION
## Why

The weekly **🔒 Security & Quality** run went red ([run 31366904154](https://github.com/nesquikm/mcp-rubber-duck/actions/runs/31366904154)). `audit-ci` reported **12 advisories (5 moderate, 7 high)** across `brace-expansion`, `fast-uri`, `hono`, `ip-address`, `js-yaml`, `nanoid`, `tar` and `undici`. The Security tab also had **8 open Trivy alerts**, and every job was annotating the Node 20 action deprecation.

## What changed

### 1. Dependencies — every override-reachable advisory cleared

| package | before | after | note |
|---|---|---|---|
| `hono` | 4.12.32 | 4.13.1 | 4 advisories, prod via MCP SDK |
| `fast-uri` | 3.1.4 | 3.1.5 | prod via `ajv` |
| `ip-address` | 10.2.0 | 10.5.0 | 3 advisories (SSRF / trust-boundary) |
| `express-rate-limit` | 8.3.0 | 8.6.2 | drops its exact `10.1.0` ip-address pin |
| `js-yaml` | 4.3.0 | 4.3.1 | |
| `nanoid` | 3.3.16 | 3.3.18 | via postcss ← vite |
| `undici` | 6.27.0 / 7.28.0 | 6.28.0 / 7.29.0 | two reachable copies, different majors |
| `brace-expansion` | 1.1.16 / 2.1.2 | 1.1.18 / 2.1.4 | backports have since shipped |

`brace-expansion` and `undici` needed **versioned override keys** — a single range would push `@actions/http-client`'s `^6.23.0` onto a v7 API.

### 2. audit-ci allowlist — path-scoped

Everything left resolves to `node_modules/npm/node_modules/*`, bundled inside the npm CLI tarball where `overrides` cannot reach. Verified npm **11.18.0, 11.19.0 and 12.0.2 all bundle the identical stale set**, so bumping the `npm` override gains nothing today.

Those 9 advisories are allowlisted as `GHSA-ID|path` rather than bare IDs, so a *reachable* reintroduction still fails CI — the bundled copy renders as `ip-address`, the reachable one as `express-rate-limit>ip-address`. Verified by mutating an entry: CI goes red. The cases where this does **not** discriminate (undici, brace-expansion) are documented in a new `$scoping` key instead of left implicit.

### 3. Stale rationales corrected

- **`.trivyignore`** suppressed 4 undici CVEs already fixed in 6.27.0/7.28.0/8.5.0 — a bar every copy now meets, so they matched nothing. Their removal trigger was unreachable too: it referenced an "orphaned undici 6.21.0 lock entry" that has never existed (the 6.21.0 is `undici-types`, types-only).
- **`.github/dependabot.yml`** named a version that never existed (`undici@6.26.0`) and blamed node-gyp, which is not the blocker. The `ignore` rule is **kept**, re-justified on the accurate reason: undici is governed by `overrides`, which Dependabot does not edit.

### 4. CI hardening

- **Node 20 deprecation fixed:** checkout v4→v7, setup-node v4→v7, docker actions v3/v5→v4/v7. Breaking changes checked against actual usage.
- **Supply chain:** `trivy-action@master` → pinned commit `ed142fd0` (v0.36.0) at all 4 sites; `npx audit-ci` → `audit-ci@7.1.0`. An unpinned gate is not a gate.
- **Least privilege:** `semantic-release.yml` granted `contents/issues/pull-requests/packages/security-events: write` + `id-token` at top level, inherited by all 6 jobs — including 4 that just run `npm ci` with install scripts enabled. Dropped to `contents: read`; release/docker opt back in. `persist-credentials: false` on the 8 checkouts that don't need a token.
- **Robustness:** concurrency groups (cancel stale checks, never cancel a release) and `timeout-minutes` on all 11 jobs.
- **Quality Gates now gates.** It only echoed pass/fail into the summary, so it was structurally always green. `master` has no branch protection today, so nothing consumes it yet — it now just reports honestly.

### 5. Test gap closed

`validateToolArguments` had zero coverage despite being the project's only Ajv surface — and it **fails open** (compile errors are caught and treated as valid), so a regression would be silent. Added 5 tests. Verified non-vacuous: stubbing the function to always return valid turns 3 of them red.

## Verification (all local, before this PR)

| check | result |
|---|---|
| `npm run typecheck` | ✅ exit 0 |
| `npm run lint` | ✅ exit 0 |
| `npm test` | ✅ **1155 passed**, 53 suites (was 1150) |
| `npm run build` | ✅ tsc + 4 UI bundles |
| `npx audit-ci@7.1.0` | ✅ **Passed npm security audit** (was exit 1) |
| `actionlint` | ✅ 47 findings, **identical to HEAD** — all pre-existing shellcheck info, zero expression/action-ref errors |

**Rebuilt MCP server smoke test** — `dist/index.js` over stdio: clean `initialize` handshake, all **12 tools** listed, banner correctly on stderr (no stdout pollution).

**Affected functionality checked:**
- `ajv` + `fast-uri` — `$ref` resolution, type coercion, defaults and error messages all correct on 3.1.5.
- `semantic-release` — `--dry-run` loads all 11 plugins on the new undici, correctly declines to publish off `master`.
- Runtime module tracing (CJS+ESM) confirms `hono`, `@hono/node-server`, `express`, `express-rate-limit` and `ip-address` load **0 modules** in this stdio server — the `$overrides-rationale` claim in `package.json` still holds.

## Notes

- Supersedes the 3 open Dependabot PRs (#135, #138, #139) — they can be closed once this merges.
- The failing **Dependabot Updates** runs are a separate symptom: `pull_request_exists_for_latest_version`, caused by those same stale open PRs.
- **Not done, deliberately:** `security.yml` and `semantic-release.yml` run the same 4 jobs on every master push. Converting the former into a reusable workflow would roughly halve CI cost, but it restructures how CI is wired — left for its own PR.