### PR TITLE
fix(mcp-bridge): fail loud on a global trusted-tools "*", and document the filesystem recipe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Detailed reference documentation for MCP Rubber Duck.
 | [Tools](./tools.md) | All 15 tools with input schemas and examples |
 | [Prompts](./prompts.md) | All 8 prompt templates with arguments and usage |
 | [CLI Providers](./cli-providers.md) | Coding agents as ducks: presets, custom, output formats |
-| [MCP Bridge](./mcp-bridge.md) | Connect ducks to external MCP servers |
+| [MCP Bridge](./mcp-bridge.md) | Connect ducks to external MCP servers: approval modes, trusted tools, filesystem read-access recipe |
 | [Guardrails](./guardrails.md) | Rate limiting, token limits, pattern blocking, PII redaction |
 | [Docker](./docker.md) | Multi-platform deployment, Compose profiles, Raspberry Pi |
 | [Provider Setup](./provider-setup.md) | Ollama, LM Studio, Gemini, Groq, Together AI |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,8 +70,9 @@ LOG_LEVEL=info
 
 # MCP Bridge Settings (Optional)
 MCP_BRIDGE_ENABLED=true                      # Enable ducks to access external MCP servers
-MCP_APPROVAL_MODE=trusted                    # always, trusted, or never
-MCP_APPROVAL_TIMEOUT=300                     # seconds
+MCP_APPROVAL_MODE=trusted                    # always (default), trusted, or never
+MCP_APPROVAL_TIMEOUT=300                     # seconds (default: 300)
+MCP_MAX_TOOL_ROUNDS=10                       # Tool-calling rounds per request, 1-50 (default: 10)
 
 # MCP Server: Context7 Documentation (Example)
 MCP_SERVER_CONTEXT7_TYPE=http

--- a/docs/mcp-bridge.md
+++ b/docs/mcp-bridge.md
@@ -31,10 +31,11 @@ MCP_TRUSTED_TOOLS_CONTEXT7="*"
 
 ## Approval Modes
 
-**`always`**: Every tool call requires approval (with session-based memory)
+**`always`** (default): Every tool call requires approval (with session-based memory)
 - First use of a tool (with specific arguments) -> requires approval
 - Subsequent *identical* calls (same provider + server + tool + arguments) -> automatic, until the approval TTL expires
 - A material change in arguments, or TTL expiry -> re-prompts
+- Trusted-tool lists are **ignored** in this mode — trust is only consulted in `trusted` mode
 
 **`trusted`**: Only untrusted tools require approval
 - Tools in trusted lists execute immediately
@@ -51,14 +52,34 @@ Configure trust levels per MCP server for granular security:
 MCP_TRUSTED_TOOLS_CONTEXT7="*"
 
 # Trust specific filesystem operations only
-MCP_TRUSTED_TOOLS_FILESYSTEM="read-file,list-directory"
+MCP_TRUSTED_TOOLS_FILESYSTEM="read_text_file,list_directory"
 
-# Trust specific GitHub tools
-MCP_TRUSTED_TOOLS_GITHUB="get-repo-info,list-issues"
+# Trust specific tools from another server — substitute that server's real
+# tool names; they are matched exactly, so placeholders never match
+MCP_TRUSTED_TOOLS_GITHUB="<tool_name>,<other_tool_name>"
 
-# Global fallback for servers without specific config
-MCP_TRUSTED_TOOLS="common-safe-tool"
+# Global fallback, used ONLY for servers that have no MCP_TRUSTED_TOOLS_<SERVER> entry
+MCP_TRUSTED_TOOLS="common_safe_tool"
 ```
+
+Tool names are matched by **exact string** (`read_text_file`, not `read-file`) against
+either the bare tool name or the `server:tool` form. A name that no connected server
+actually exposes is inert — it silently trusts nothing. Confirm the real names with the
+`mcp_status` tool.
+
+Two things about the global list are easy to get wrong:
+
+- **A per-server list replaces the global list, it does not extend it.** If
+  `MCP_TRUSTED_TOOLS_FILESYSTEM` is set, `MCP_TRUSTED_TOOLS` is never consulted for the
+  `filesystem` server. Any name you still want trusted there has to be repeated in the
+  per-server list.
+- **`"*"` is not supported in the global list.** The wildcard is only honoured in a
+  per-server list; in `MCP_TRUSTED_TOOLS` it is treated as a literal tool name and
+  matches nothing (a warning is logged at startup if you set it, except in `never` mode
+  where nothing is gated anyway). To trust everything from one server use
+  `MCP_TRUSTED_TOOLS_<SERVER>="*"` — which requires `MCP_APPROVAL_MODE="trusted"`, since
+  the default `always` ignores trusted lists entirely; to drop approvals entirely use
+  `MCP_APPROVAL_MODE="never"`.
 
 ## MCP Server Configuration
 
@@ -102,6 +123,109 @@ Now your ducks can search and retrieve documentation from Context7:
 Ask: "Can you find React hooks documentation from Context7 and return only the key concepts?"
 Duck: *searches Context7 and returns focused, essential React hooks information*
 ```
+
+## Example: Give Ducks Read Access to Files
+
+Wire the official [`@modelcontextprotocol/server-filesystem`](https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem)
+through the bridge over stdio, with only its read tools on the trusted list:
+
+```bash
+# Enable the bridge; anything not trusted stops for approval
+MCP_BRIDGE_ENABLED="true"
+MCP_APPROVAL_MODE="trusted"
+
+# Filesystem server over stdio. ARGS is comma-split, one argv entry per element,
+# and the trailing entries are the directories the server is allowed to touch.
+MCP_SERVER_FILESYSTEM_TYPE="stdio"
+MCP_SERVER_FILESYSTEM_COMMAND="npx"
+MCP_SERVER_FILESYSTEM_ARGS="-y,@modelcontextprotocol/server-filesystem@2026.7.10,/Users/you/projects/my-app,/Users/you/notes"
+MCP_SERVER_FILESYSTEM_ENABLED="true"
+
+# Read-only allowlist: only these run without an approval prompt
+MCP_TRUSTED_TOOLS_FILESYSTEM="read_text_file,read_multiple_files,list_directory,directory_tree,search_files,get_file_info,list_allowed_directories"
+```
+
+Now a duck can read and navigate those two directories without interrupting you:
+
+```
+Ask: "Read /Users/you/projects/my-app/src/config/config.ts and summarise how env vars override the config file."
+Duck: *calls read_text_file, returns a summary*
+```
+
+The seven names above are the read-only tools of `@modelcontextprotocol/server-filesystem`
+version `2026.7.10`; that release also ships `read_file` (deprecated in favour of
+`read_text_file`), `read_media_file`, and `list_directory_with_sizes`, which you can add if
+you want them. Tool names are matched exactly, so **confirm the names your installed version
+actually exposes with the `mcp_status` tool** — it lists each connected server, its tool
+count, and the first three tool names.
+
+Caveats worth knowing before you paste this in:
+
+- **`ARGS` is split on commas and each element is trimmed.** A path containing a comma
+  cannot be expressed. A *trailing* comma is worse than a typo: it produces an empty argv
+  entry, which the filesystem server resolves to the working directory of the rubber-duck
+  process and silently adds to the allowed directories. Use absolute paths, no trailing
+  comma.
+- **`MCP_SERVER_<NAME>_ENABLED` is truthy unless it is exactly `"false"`.** `"0"`, `"no"`,
+  and an unset value all leave the server enabled.
+- **Deleting `MCP_BRIDGE_ENABLED` does not turn the bridge off.** When the variable is
+  *set*, the bridge is enabled only if the value is exactly `"true"`; when it is *unset*,
+  the mere presence of any `MCP_SERVER_*` variable enables the bridge automatically — and
+  the recipe above defines several. To actually disable the bridge, set
+  `MCP_BRIDGE_ENABLED="false"` (or `"enabled": false` under `mcp_bridge` in `config.json`, which
+  wins over the environment) rather than removing the line.
+- **Server names are normalised, and the trusted-tools variable must match.** The `<NAME>`
+  in `MCP_SERVER_<NAME>_*` is lowercased with underscores turned into hyphens, so
+  `MCP_SERVER_FILESYSTEM_*` registers the server as `filesystem`.
+  `MCP_TRUSTED_TOOLS_<NAME>` goes through the same normalisation, so the two must use the
+  same spelling of `<NAME>`: `MCP_SERVER_MY_FILES_*` (server `my-files`) pairs with
+  `MCP_TRUSTED_TOOLS_MY_FILES`, never with `MCP_TRUSTED_TOOLS_MYFILES`.
+- **CLI ducks never get bridge tools.** Providers of `type: "cli"` are skipped when
+  MCP-enhanced providers are built, and calls to them fall back to a plain chat request.
+  Only HTTP/OpenAI-compatible ducks can call filesystem tools.
+- **`npx` has to be on `PATH`, and the child gets a stripped environment.** The stdio child
+  is spawned without a shell and with only the MCP SDK's default inherited variables —
+  `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER` on macOS and Linux. Rubber-duck passes
+  no extra `env` and no `cwd`, so none of your other variables (API keys included) reach the
+  child, and it inherits rubber-duck's working directory. If rubber-duck is launched by a
+  GUI app with a minimal `PATH`, give the absolute path instead, e.g.
+  `MCP_SERVER_FILESYSTEM_COMMAND="/usr/local/bin/npx"`.
+- **Pin the server version.** `npx -y` resolves to the latest release. Because trust is
+  exact-string matching, an upstream rename or removal empties your allowlist without any
+  error: the tool still exists under its new name, it just is not trusted any more, so every
+  call starts prompting (or, in `never` mode, runs unguarded). A pinned version keeps the
+  names stable until you choose to bump it.
+
+### Caveat: trusted tools gate calls, not tool exposure
+
+The trusted-tools list is an **approval filter, not a visibility filter**.
+
+`getFunctionDefinitions()` in `src/services/function-bridge.ts` turns *every* tool of *every*
+connected server into a function definition and hands the whole set to the model — there is
+no trust filtering at that step. Trust is consulted only later, in `handleFunctionCall()`,
+once a call has actually arrived.
+
+So the read-only allowlist above does **not** hide `write_file`, `edit_file`, `move_file`, or
+`create_directory` from the duck. The duck still sees them and can still decide to call one;
+what you get is an approval prompt instead of a silent write. That prompt is the whole of the
+protection.
+
+Two ways to throw it away:
+
+- `MCP_TRUSTED_TOOLS_FILESYSTEM="*"` trusts every tool from that server, writes included —
+  no prompt at all. This is the trap: the wildcard looks like a convenience and is actually
+  the entire security boundary.
+- `MCP_APPROVAL_MODE="never"` skips approval for every server.
+
+The bridge cannot work read-only-ness out for you either. The filesystem server has no
+read-only flag — its arguments are just the allowed directories — and while it does annotate
+its tools with `readOnlyHint`, the bridge's `MCPTool` type keeps only `serverName`, `name`,
+`description`, and `inputSchema`, so annotations are discarded on the way in and cannot be
+used for filtering.
+
+A genuine read-only guarantee needs a server that has no write tools at all, plus OS-level
+protection: a read-only bind mount, a dedicated user with no write permission on those paths,
+or a container with the directory mounted `:ro`.
 
 ## Token Optimization Benefits
 

--- a/src/services/function-bridge.ts
+++ b/src/services/function-bridge.ts
@@ -54,6 +54,39 @@ export class FunctionBridge {
     Object.entries(trustedToolsByServer).forEach(([serverName, tools]) => {
       this.trustedToolsByServer.set(serverName, new Set(tools));
     });
+
+    this.warnIfGlobalWildcard();
+  }
+
+  /**
+   * A global trusted-tools list containing '*' trusts nothing: the global list is
+   * matched literally in handleFunctionCall, so every call still hits the approval
+   * gate. That fail-closed behaviour is deliberate — honouring a global wildcard
+   * would silently switch off every approval prompt on upgrade — but it is invisible
+   * to a user who believes they disabled the prompts, so say so loudly instead.
+   */
+  private warnIfGlobalWildcard(): void {
+    // In 'never' mode nothing is gated at all, so the message would be pure noise.
+    if (this.approvalMode === 'never' || !this.trustedTools.has('*')) {
+      return;
+    }
+
+    // 'always' mode never consults trusted lists, so recommending a per-server list
+    // on its own would send the user to a setting that changes nothing for them.
+    const remedy =
+      this.approvalMode === 'always'
+        ? 'This mode ignores trusted tools entirely: set MCP_APPROVAL_MODE=trusted first, then ' +
+          'use MCP_TRUSTED_TOOLS_<SERVER> (mcp_bridge.trusted_tools_by_server) to trust one ' +
+          'server — or use MCP_APPROVAL_MODE=never to skip approval entirely.'
+        : 'To trust every tool of one server use MCP_TRUSTED_TOOLS_<SERVER> ' +
+          '(mcp_bridge.trusted_tools_by_server); to skip approval entirely use ' +
+          'MCP_APPROVAL_MODE=never.';
+
+    logger.warn(
+      "Ignoring '*' in the global trusted tools list (MCP_TRUSTED_TOOLS, config key " +
+        'mcp_bridge.trusted_tools): a global wildcard is matched literally, trusts no tool, ' +
+        `and approval is still required. ${remedy}`
+    );
   }
 
   async getFunctionDefinitions(): Promise<FunctionDefinition[]> {
@@ -392,6 +425,7 @@ export class FunctionBridge {
   ): void {
     this.trustedTools = new Set(trustedTools);
     logger.info(`Updated global trusted tools list: ${Array.from(this.trustedTools).join(', ')}`);
+    this.warnIfGlobalWildcard();
 
     if (trustedToolsByServer) {
       this.trustedToolsByServer.clear();

--- a/tests/function-bridge.test.ts
+++ b/tests/function-bridge.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals
 import { ApprovalService } from '../src/services/approval';
 import { FunctionBridge } from '../src/services/function-bridge';
 import { MCPClientManager } from '../src/services/mcp-client-manager';
+// Real logger singleton: `jest.mock(path)` below is a no-op under this repo's
+// ts-jest ESM config, so warning assertions must spy on the real object.
+import { logger } from '../src/utils/logger.js';
 
 // Mock loggers to avoid console noise during tests
 jest.mock('../src/utils/logger');
@@ -315,5 +318,234 @@ describe('FunctionBridge tool-argument validation', () => {
 
     expect(result.success).toBe(true);
     expect(callToolSpy).toHaveBeenCalledWith('files', 'write_file', { anything: 123 });
+  });
+});
+
+/**
+ * FR 8WGQ4P — trusted-tool resolution (issue #129).
+ *
+ * A global `'*'` is matched literally and therefore trusts nothing; that
+ * fail-closed behaviour is deliberate and stays. What is missing is a loud
+ * warning (AC.1/AC.2). AC.3/AC.4 pin the surrounding resolution rules — the
+ * per-server list *replaces* the global one, and `always` mode ignores trust
+ * entirely — so a future refactor cannot quietly loosen them.
+ *
+ * Every case asserts both the returned result shape and the `callTool` spy, so
+ * no test can pass vacuously. Bridges are built inside each test (not in
+ * `beforeEach`) because the warning fires at construction time and the
+ * `logger.warn` spy has to be installed first.
+ */
+describe('trusted-tool resolution', () => {
+  let approvalService: ApprovalService;
+  let mcpManager: MCPClientManager;
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  // The wildcard warning must name both routes the global list can arrive by.
+  const ENV_KEY = 'MCP_TRUSTED_TOOLS';
+  const CONFIG_KEY = 'mcp_bridge.trusted_tools';
+
+  /** Flattened text of every logger.warn call, for substring assertions. */
+  const warnings = (): string[] =>
+    warnSpy.mock.calls.map((call) => (call as unknown[]).map((arg) => String(arg)).join(' '));
+
+  const wildcardWarnings = (): string[] =>
+    warnings().filter((text) => text.includes(ENV_KEY) || text.includes(CONFIG_KEY));
+
+  beforeEach(() => {
+    approvalService = new ApprovalService(300);
+    mcpManager = new MCPClientManager([]);
+    // Installed before any bridge is constructed, so constructor-time warnings are captured.
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
+  });
+
+  afterEach(() => {
+    approvalService.shutdown();
+    jest.restoreAllMocks();
+  });
+
+  // ---- AC-8WGQ4P.1: fail closed on a global wildcard, and say so -----------
+
+  it('AC.1 refuses a call when the global list is ["*"] in trusted mode', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, ['*'], 'trusted');
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.needsApproval).toBe(true);
+    expect(result.approvalId).toBeDefined();
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC.1 warns exactly once at construction, naming MCP_TRUSTED_TOOLS and mcp_bridge.trusted_tools', () => {
+    new FunctionBridge(mcpManager, approvalService, ['*'], 'trusted');
+
+    const matched = wildcardWarnings();
+    expect(matched).toHaveLength(1);
+    expect(matched[0]).toContain(ENV_KEY);
+    expect(matched[0]).toContain(CONFIG_KEY);
+    // No other warning noise from construction.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('AC.1 emits no wildcard warning for a non-wildcard global list', () => {
+    new FunctionBridge(mcpManager, approvalService, ['read_file', 'files:write_file'], 'trusted');
+
+    expect(wildcardWarnings()).toHaveLength(0);
+  });
+
+  // ---- AC-8WGQ4P.2: the warning is mode-aware and not constructor-only -----
+
+  it('AC.2 suppresses the wildcard warning in never mode', () => {
+    new FunctionBridge(mcpManager, approvalService, ['*'], 'never');
+
+    expect(wildcardWarnings()).toHaveLength(0);
+  });
+
+  it('AC.2 warns when updateTrustedTools swaps in a global wildcard at runtime', () => {
+    const bridge = new FunctionBridge(mcpManager, approvalService, ['read_file'], 'trusted');
+    expect(wildcardWarnings()).toHaveLength(0);
+
+    bridge.updateTrustedTools(['*']);
+
+    const matched = wildcardWarnings();
+    expect(matched).toHaveLength(1);
+    expect(matched[0]).toContain(ENV_KEY);
+    expect(matched[0]).toContain(CONFIG_KEY);
+  });
+
+  // In 'always' mode the per-server remedy is inert on its own (AC.4 pins that
+  // trusted lists are ignored there), so the warning must lead with the mode switch.
+  it('AC.2 tells an always-mode user to switch mode before recommending a per-server list', () => {
+    new FunctionBridge(mcpManager, approvalService, ['*'], 'always');
+
+    const matched = wildcardWarnings();
+    expect(matched).toHaveLength(1);
+    expect(matched[0]).toContain('MCP_APPROVAL_MODE=trusted');
+    expect(matched[0]).toContain('ignores trusted tools entirely');
+  });
+
+  // ---- AC-8WGQ4P.3: per-server resolution shadows the global list ----------
+
+  it('AC.3 per-server ["*"] auto-approves any tool on that server', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, [], 'trusted', {
+      files: ['*'],
+    });
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__delete_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'delete_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.needsApproval).toBeUndefined();
+    expect(callToolSpy).toHaveBeenCalledTimes(1);
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'delete_file', { path: '/a.txt' });
+  });
+
+  it('AC.3 per-server list naming the tool exactly auto-approves it', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, [], 'trusted', {
+      files: ['read_file'],
+    });
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'read_file', { path: '/a.txt' });
+  });
+
+  it('AC.3 per-server list that omits the tool requires approval', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, [], 'trusted', {
+      files: ['read_file'],
+    });
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__write_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'write_file',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.needsApproval).toBe(true);
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC.3 a per-server list replaces the global list rather than extending it', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    // `write_file` is globally trusted, but `files` has its own (narrower) list.
+    const bridge = new FunctionBridge(mcpManager, approvalService, ['write_file'], 'trusted', {
+      files: ['read_file'],
+    });
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__write_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'write_file',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.needsApproval).toBe(true);
+    expect(callToolSpy).not.toHaveBeenCalled();
+  });
+
+  // ---- AC-8WGQ4P.4: global key forms, and `always` ignores trust -----------
+
+  it('AC.4 global list auto-approves a bare tool name', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, ['read_file'], 'trusted');
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.needsApproval).toBeUndefined();
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'read_file', { path: '/a.txt' });
+  });
+
+  it('AC.4 global list auto-approves a server:tool composite key', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, ['files:read_file'], 'trusted');
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(true);
+    expect(callToolSpy).toHaveBeenCalledWith('files', 'read_file', { path: '/a.txt' });
+  });
+
+  it('AC.4 always mode ignores trusted lists even with a per-server wildcard', async () => {
+    const callToolSpy = jest.spyOn(mcpManager, 'callTool').mockResolvedValue({ ok: true });
+    const bridge = new FunctionBridge(mcpManager, approvalService, ['*'], 'always', {
+      files: ['*'],
+    });
+
+    const result = await bridge.handleFunctionCall('duckA', 'mcp__files__read_file', {
+      path: '/a.txt',
+      _mcp_server: 'files',
+      _mcp_tool: 'read_file',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.needsApproval).toBe(true);
+    expect(result.approvalId).toBeDefined();
+    expect(callToolSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #130. Refs #129.

Triage of both issues found that #129's headline fix was the wrong remedy and #130 was a real gap, so the scope here is deliberately narrower than #129 asks for.

## `fix:` — global trusted-tools wildcard

`*` is honored in a **per-server** trusted list but matched literally in the **global** one, so `MCP_TRUSTED_TOOLS="*"` never trusted anything and users kept getting approval prompts they believed they had disabled.

**Honoring it would be a security loosening**, not a bug fix: it would silently switch off every approval prompt on upgrade for anyone who had set the string speculatively, and `MCP_APPROVAL_MODE=never` already expresses blanket trust. So this fails loud instead — `warnIfGlobalWildcard()` names the settings that actually work, and stays quiet in `never` mode where nothing is gated. It also runs from `updateTrustedTools()`, so a list swapped in at runtime is diagnosed the same way.

The remedy is mode-aware: in the default `always` mode trusted lists are ignored entirely, so recommending a per-server list on its own would send the user to a setting that changes nothing — there the warning leads with `MCP_APPROVAL_MODE=trusted`.

Trust resolution itself is **unchanged**. The per-server list deliberately *replaces* the global list rather than extending it — ORing them would let a global entry silently widen a narrow per-server allowlist.

**The two other fixes proposed in #129 are deliberately not implemented.** Deriving the server/tool pair from the function name, and guarding the greedy `MCP_SERVER_(.+)_(.+)` split, are both recorded as refuted false positives in the 2026-06-15 review: the regex only discovers candidate names, and every tool already has a cached schema.

### Tests

The trusted-tool branch had **zero** coverage, which is why the asymmetry survived this long. Thirteen tests now pin it: per-server wildcard / exact-name / miss, global bare and `server:tool` key forms, per-server-shadows-global precedence, fail-closed handling of a global wildcard, the mode-aware remedy, and the fact that `always` mode ignores trusted lists entirely. Each asserts both the result shape and a `callTool` spy, so none can pass vacuously — confirmed by mutation: neutering the guard, the `always` branch, or the mode-aware remedy each turns the matching test red.

## `docs:` — filesystem bridge recipe (#130)

A copy-pasteable recipe for read-only file access, with the traps only discoverable by reading the source: `MCP_APPROVAL_MODE` must be `trusted` (the default `always` ignores trusted lists entirely), `ARGS` is comma-split with no empty-filtering (a trailing comma silently adds the server's cwd to the allowed directories), and server names are lowercased with `_`→`-`.

Plus the caveat the issue asked for: **trusted tools gate calls, not tool exposure.** Every tool of every connected server is sent to the model on each request; trust is only consulted when a call arrives. Allowlisting read tools does not hide `write_file`/`edit_file`/`move_file` — it only makes them prompt. Setting the per-server list to `"*"` removes even that.

It also corrects docs that were **wrong**, not merely incomplete: the existing `MCP_TRUSTED_TOOLS_FILESYSTEM="read-file,list-directory"` example used hyphens against exact-match matching, so it had never trusted anything.

## Verification

`npm run typecheck && npm run lint && npm test` → **1168 passed, 53 suites**, plus `npm run build`.

Beyond the static gate this was verified at runtime against the built `dist/`: the warning fires from both call sites, a global `*` still returns `needsApproval: true`, `never` mode stays silent, and per-server/exact-name trust still executes. Live MCP calls (`list_ducks`, `mcp_status`, `list_models`, `get_usage_stats`, `ask_duck`, `compare_ducks`) all returned clean against a server started from the new build — no transport regression, stdout stays pure.

That runtime pass earned its keep by catching a defect no static check could: an earlier draft of the warning named the config key `mcp.trusted_tools`, but the only key the Zod schema accepts is `mcp_bridge.*`, and unknown keys are **silently stripped** — so following the wrong key left the bridge enabled while the user believed they had disabled it. Fixed in the source, the docs, and the test that had pinned it.