### PR TITLE
docs: add DaoXE multi-model gateway to provider setup

### DIFF
--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -39,6 +39,19 @@ CUSTOM_TOGETHER_DEFAULT_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo
 CUSTOM_TOGETHER_NICKNAME=Together Duck
 ```
 
+## DaoXE (multi-model gateway)
+1. Get API key from https://daoxe.com (sign up with GitHub, Telegram or Passkey)
+2. Configure as a custom provider:
+```env
+CUSTOM_DAOXE_API_KEY=...
+CUSTOM_DAOXE_BASE_URL=https://daoxe.com/v1
+CUSTOM_DAOXE_DEFAULT_MODEL=claude-sonnet-4-6
+CUSTOM_DAOXE_NICKNAME=DaoXE Duck
+```
+3. Model ids are account-scoped — run `curl -H "Authorization: Bearer $CUSTOM_DAOXE_API_KEY" https://daoxe.com/v1/models` once and use an exact id from the response. The catalog drifts as upstream providers ship, so don't hardcode a list across deployments.
+
+> DaoXE fronts hundreds of models from many providers behind one key, and also exposes a native Anthropic Messages endpoint for Claude-native clients. Not available in mainland China.
+
 ## Verifying OpenAI Compatibility
 
 To check if a provider is OpenAI-compatible:


### PR DESCRIPTION
Adds a DaoXE section to `docs/provider-setup.md`, following the existing custom-provider pattern (Together AI).

- Env vars match the `CUSTOM_{NAME}_{API_KEY|BASE_URL|MODELS|DEFAULT_MODEL|NICKNAME}` regex in `src/config/config.ts` (verified against source, not guessed).
- The example default model id is from the gateway's public catalog entry on models.dev; the section notes model ids are account-scoped and points the reader at `GET /models` rather than implying a fixed list, since the catalog drifts as upstream providers ship.

Docs-only change — no runtime code touched.